### PR TITLE
feat(admin): enhance withdraw security

### DIFF
--- a/src/middleware/ipWhitelist.ts
+++ b/src/middleware/ipWhitelist.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+const whitelist = (process.env.ADMIN_IP_WHITELIST || '')
+  .split(',')
+  .map(ip => ip.trim())
+  .filter(Boolean);
+
+export function adminIpWhitelist(req: Request, res: Response, next: NextFunction) {
+  const header = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  const ip = header.split(',')[0].trim();
+  if (whitelist.length > 0 && !whitelist.includes(ip)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+

--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -3,6 +3,7 @@ import { Router, Request, Response, NextFunction } from 'express'
 import * as ctrl from '../../controller/admin/merchant.controller'
 import * as exportCtrl from '../../controller/admin/merchant.controller'
 import { authMiddleware, AuthRequest, requireSuperAdminAuth } from '../../middleware/auth'
+import { adminIpWhitelist } from '../../middleware/ipWhitelist'
 import subMerchantRouter from './subMerchant.routes'   // ← import
 
 const router = Router()
@@ -43,7 +44,7 @@ router.get('/dashboard/profit',       ctrl.getPlatformProfit)
 router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
-router.post('/dashboard/withdraw', requireSuperAdminAuth, ctrl.adminWithdraw)
+router.post('/dashboard/withdraw', adminIpWhitelist, requireSuperAdminAuth, ctrl.adminWithdraw)
 router.post(
   '/dashboard/validate-account',
   requireSuperAdminAuth,


### PR DESCRIPTION
## Summary
- require TOTP verification and enforce max amount on admin withdraw
- compute and deduct balances atomically before initiating PG withdrawal
- add admin audit log and IP whitelist middleware for admin withdraw route

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c79975ac83288998b28eed4e157c