### PR TITLE
Restrict client user creation to super admins

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/app.js",
     "dev": "ts-node src/app.ts",
     "callback-worker": "ts-node src/worker/callbackQueue.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test -r ts-node/register test/**/*.test.ts"
   },
   "author": "",
   "license": "ISC",
@@ -59,6 +59,8 @@
     "@types/uuid": "^10.0.0",
     "axios": "^1.7.4",
     "prisma": "^5.18.0",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   }
 }

--- a/src/route/admin/clientUser.routes.ts
+++ b/src/route/admin/clientUser.routes.ts
@@ -1,16 +1,26 @@
 import { Router } from 'express'
-import { authMiddleware, AuthRequest } from '../../middleware/auth'
-import { listClientUsers, createClientUser, deleteClientUser } from '../../controller/admin/clientUser.controller'
+import {
+  authMiddleware,
+  AuthRequest,
+  requireSuperAdminAuth,
+} from '../../middleware/auth'
+import {
+  listClientUsers,
+  createClientUser,
+  deleteClientUser,
+} from '../../controller/admin/clientUser.controller'
 
 const router = Router({ mergeParams: true })
 
 router.use(authMiddleware, (req: AuthRequest, res, next) => {
-  if (req.userRole !== 'ADMIN') return res.status(403).json({ error: 'Forbidden' })
+  if (req.userRole !== 'ADMIN' && req.userRole !== 'SUPER_ADMIN') {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
   next()
 })
 
 router.get('/', listClientUsers)
-router.post('/', createClientUser)
+router.post('/', requireSuperAdminAuth, createClientUser)
 router.delete('/:userId', deleteClientUser)
 
 export default router

--- a/test/clientUser.routes.test.ts
+++ b/test/clientUser.routes.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+import router from '../src/route/admin/clientUser.routes'
+import { config } from '../src/config'
+import { prisma } from '../src/core/prisma'
+
+// Stub database interactions
+(prisma as any).clientUser = {
+  findUnique: async () => null,
+  create: async ({ data }: any) => ({ id: 'new-id', email: data.email }),
+  delete: async () => {},
+}
+;(prisma as any).adminLog = { create: async () => {} }
+
+const app = express()
+app.use(express.json())
+app.use('/clients/:clientId/users', router)
+
+const adminToken = jwt.sign({ sub: '1', role: 'ADMIN' }, config.api.jwtSecret)
+const superToken = jwt.sign({ sub: '2', role: 'SUPER_ADMIN' }, config.api.jwtSecret)
+
+test('admin user cannot create client user', async () => {
+  const res = await request(app)
+    .post('/clients/abc/users')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ email: 'test@example.com', password: 'pass' })
+
+  assert.equal(res.status, 403)
+})
+
+test('super admin can create client user', async () => {
+  const res = await request(app)
+    .post('/clients/abc/users')
+    .set('Authorization', `Bearer ${superToken}`)
+    .send({ email: 'test@example.com', password: 'pass' })
+
+  assert.equal(res.status, 201)
+  assert.deepEqual(res.body, {
+    id: 'new-id',
+    email: 'test@example.com',
+  })
+})


### PR DESCRIPTION
## Summary
- Ensure client user creation route requires super admin role
- Add tests for admin vs super admin access
- Add testing dependencies and script

## Testing
- `npx prisma generate --schema=src/prisma/schema.prisma`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890cf850fd48328b3b60eda457c7738