### PR TITLE
feat: persist admin ip whitelist

### DIFF
--- a/frontend/src/pages/super-admin/ip-whitelist.tsx
+++ b/frontend/src/pages/super-admin/ip-whitelist.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import api from '@/lib/api'
+import { useRequireAuth } from '@/hooks/useAuth'
+
+export default function IpWhitelistPage() {
+  useRequireAuth()
+  const [ips, setIps] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    api
+      .get<{ data: string[] }>('/admin/ip-whitelist')
+      .then(res => setIps(res.data.data.join(', ')))
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const save = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const arr = ips
+        .split(',')
+        .map(ip => ip.trim())
+        .filter(Boolean)
+      await api.put('/admin/ip-whitelist', { ips: arr })
+    } catch (e: any) {
+      setError(e.response?.data?.error || 'Failed to save')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (loading) return <div>Loading…</div>
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>IP Whitelist</h1>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      <textarea
+        value={ips}
+        onChange={e => setIps(e.target.value)}
+        rows={4}
+        style={{ width: '100%', marginBottom: '1rem' }}
+        placeholder="Comma separated IPs"
+      />
+      <button onClick={save} disabled={loading}>
+        {loading ? 'Saving…' : 'Save'}
+      </button>
+    </div>
+  )
+}
+

--- a/readme.md
+++ b/readme.md
@@ -38,3 +38,16 @@ openssl rsa -pubout -in private.pem -out public.pem
 openssl pkey -pubin -in public.pem -text
 ```
 # laucxserver
+
+## Admin IP Whitelist
+
+Super Admins can restrict certain administrative actions to specific IP addresses.
+
+### API
+
+- `GET /api/v1/admin/ip-whitelist` – returns the list of allowed IPs.
+- `PUT /api/v1/admin/ip-whitelist` – update the allowed IPs with `{ "ips": ["1.1.1.1", "2.2.2.2"] }`.
+
+The whitelist is stored in the `Setting` table under the key `admin_ip_whitelist`.
+If the setting is missing or empty, no IP restriction is applied.
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import adminClientUserRoutes from './route/admin/clientUser.routes';
 
 import adminTotpRoutes from './route/admin/totp.routes';
 import adminLogRoutes from './route/admin/log.routes';
+import adminIpWhitelistRoutes from './route/admin/ipWhitelist.routes';
 
 import usersRoutes from './route/users.routes';
 
@@ -140,6 +141,7 @@ app.use('/api/v1/admin/settings', authMiddleware, settingsRoutes);
 
 app.use('/api/v1/admin/2fa', adminTotpRoutes);
 app.use('/api/v1/admin/logs', adminLogRoutes);
+app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
 
 /* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
 app.use('/api/v1/client', clientWebRoutes);

--- a/src/controller/admin/ipWhitelist.controller.ts
+++ b/src/controller/admin/ipWhitelist.controller.ts
@@ -1,0 +1,34 @@
+import { Response } from 'express';
+import { prisma } from '../../core/prisma';
+import { AuthRequest } from '../../middleware/auth';
+import { refreshAdminIpWhitelist } from '../../middleware/ipWhitelist';
+import { logAdminAction } from '../../util/adminLog';
+
+export async function getIpWhitelist(_req: AuthRequest, res: Response) {
+  const row = await prisma.setting.findUnique({
+    where: { key: 'admin_ip_whitelist' },
+  });
+  const ips = row?.value
+    .split(',')
+    .map(ip => ip.trim())
+    .filter(Boolean) ?? [];
+  res.json({ data: ips });
+}
+
+export async function updateIpWhitelist(req: AuthRequest, res: Response) {
+  const ips: string[] = Array.isArray(req.body.ips)
+    ? req.body.ips.map((ip: string) => ip.trim()).filter(Boolean)
+    : [];
+  const value = ips.join(',');
+  await prisma.setting.upsert({
+    where: { key: 'admin_ip_whitelist' },
+    update: { value },
+    create: { key: 'admin_ip_whitelist', value },
+  });
+  await refreshAdminIpWhitelist();
+  if (req.userId) {
+    await logAdminAction(req.userId, 'updateIpWhitelist', 'admin_ip_whitelist', ips);
+  }
+  res.json({ data: ips });
+}
+

--- a/src/route/admin/ipWhitelist.routes.ts
+++ b/src/route/admin/ipWhitelist.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { requireSuperAdminAuth } from '../../middleware/auth';
+import { getIpWhitelist, updateIpWhitelist } from '../../controller/admin/ipWhitelist.controller';
+
+const router = Router();
+
+router.use(requireSuperAdminAuth);
+
+router.get('/', getIpWhitelist);
+router.put('/', updateIpWhitelist);
+
+export default router;
+

--- a/test/ipWhitelist.routes.test.ts
+++ b/test/ipWhitelist.routes.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+import router from '../src/route/admin/ipWhitelist.routes'
+import { adminIpWhitelist, refreshAdminIpWhitelist } from '../src/middleware/ipWhitelist'
+import { config } from '../src/config'
+import { prisma } from '../src/core/prisma'
+
+let currentSetting: { key: string; value: string | null } | null = {
+  key: 'admin_ip_whitelist',
+  value: '1.1.1.1',
+}
+
+;(prisma as any).setting = {
+  findUnique: async () => currentSetting,
+  upsert: async ({ where, update, create }: any) => {
+    const value = update?.value ?? create?.value
+    currentSetting = { key: where.key, value }
+    return currentSetting
+  },
+}
+;(prisma as any).adminLog = { create: async () => {} }
+
+const app = express()
+app.use(express.json())
+app.use('/admin/ip-whitelist', router)
+app.get('/secure', adminIpWhitelist, (_req, res) => res.json({ ok: true }))
+
+const superToken = jwt.sign({ sub: '1', role: 'SUPER_ADMIN' }, config.api.jwtSecret)
+
+test('get and update whitelist and enforce middleware', async () => {
+  await refreshAdminIpWhitelist()
+  let res = await request(app)
+    .get('/admin/ip-whitelist')
+    .set('Authorization', `Bearer ${superToken}`)
+  assert.deepEqual(res.body, { data: ['1.1.1.1'] })
+
+  res = await request(app).get('/secure').set('X-Forwarded-For', '1.1.1.1')
+  assert.equal(res.status, 200)
+
+  res = await request(app).get('/secure').set('X-Forwarded-For', '2.2.2.2')
+  assert.equal(res.status, 403)
+
+  res = await request(app)
+    .put('/admin/ip-whitelist')
+    .set('Authorization', `Bearer ${superToken}`)
+    .send({ ips: ['2.2.2.2'] })
+  assert.equal(res.status, 200)
+  assert.deepEqual(res.body, { data: ['2.2.2.2'] })
+
+  res = await request(app).get('/secure').set('X-Forwarded-For', '2.2.2.2')
+  assert.equal(res.status, 200)
+  res = await request(app).get('/secure').set('X-Forwarded-For', '1.1.1.1')
+  assert.equal(res.status, 403)
+})
+
+test('empty whitelist allows all', async () => {
+  currentSetting = { key: 'admin_ip_whitelist', value: '' }
+  await refreshAdminIpWhitelist()
+  const res = await request(app).get('/secure').set('X-Forwarded-For', '5.5.5.5')
+  assert.equal(res.status, 200)
+})
+


### PR DESCRIPTION
## Summary
- persist IP whitelist via settings table and cache in middleware
- add super admin API and UI to manage the whitelist
- document usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d5d9bc548328a7fccd860996f265