### PR TITLE
refactor: rely on effect for dashboard data fetch

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -397,9 +397,6 @@ async function handleAdminWithdraw(e: React.FormEvent) {
     setWdBank('')
     setWdName('')
     setIsValid(false)
-    fetchSummary()
-    fetchWithdrawals()
-    fetchAdminWithdrawals()
 
   } catch (err: any) {
     alert(err.response?.data?.error || 'Failed')
@@ -591,12 +588,6 @@ const filtered = mapped.filter(t => {
                   className={styles.applyBtn}
                   onClick={() => {
                     applyDateRange()
-                    fetchSummary()
-                    fetchProfit()
-                    fetchProfitSub()
-                    fetchAdminWithdrawals()
-                    fetchWithdrawals()
-                    fetchTransactions()
                   }}
                   disabled={!startDate || !endDate}
                 >
@@ -788,12 +779,6 @@ const filtered = mapped.filter(t => {
                   className={styles.applyBtn}
                   onClick={() => {
                     applyDateRange()
-                    fetchSummary()
-                    fetchProfit()
-                    fetchProfitSub()
-                    fetchAdminWithdrawals()
-                    fetchWithdrawals()
-                    fetchTransactions()
                   }}
                   disabled={!startDate || !endDate}
                 >


### PR DESCRIPTION
## Summary
- remove manual fetch calls in dashboard handlers
- rely on existing effect to load data when filters change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d93c2f6883288698b96f48c6f988