### PR TITLE
feat: cache sub merchant balances

### DIFF
--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,0 +1,24 @@
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const cacheMap = new Map<string, CacheEntry<any>>();
+
+export function getCache<T>(key: string): T | undefined {
+  const entry = cacheMap.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cacheMap.delete(key);
+    return undefined;
+  }
+  return entry.value as T;
+}
+
+export function setCache<T>(key: string, value: T, ttlMs: number): void {
+  cacheMap.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+export function deleteCache(key: string): void {
+  cacheMap.delete(key);
+}


### PR DESCRIPTION
## Summary
- add in-memory cache utility
- cache sub merchant balance queries with short TTL
- optionally filter dashboard summary by subMerchantId

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890dbf66a4083288e9a616c6b6a8a92