### PR TITLE
refactor: split dashboard sections into dynamic components

### DIFF
--- a/frontend/src/components/dashboard/AdminWithdrawForm.tsx
+++ b/frontend/src/components/dashboard/AdminWithdrawForm.tsx
@@ -1,0 +1,95 @@
+import Select from 'react-select'
+import { CheckCircle } from 'lucide-react'
+import { SubBalance } from '@/types/dashboard'
+import styles from '@/pages/Dashboard.module.css'
+
+interface AdminWithdrawFormProps {
+  subBalances: SubBalance[]
+  selectedSub: string
+  setSelectedSub: (v: string) => void
+  wdAmount: string
+  setWdAmount: (v: string) => void
+  wdAccount: string
+  setWdAccount: (v: string) => void
+  wdBank: string
+  setWdBank: (v: string) => void
+  wdName: string
+  bankOptions: { value: string; label: string }[]
+  isValid: boolean
+  busy: { validating: boolean; submitting: boolean }
+  error: string
+  validateBankAccount: () => void
+  handleAdminWithdraw: (e: React.FormEvent) => void
+}
+
+export default function AdminWithdrawForm({
+  subBalances,
+  selectedSub,
+  setSelectedSub,
+  wdAmount,
+  setWdAmount,
+  wdAccount,
+  setWdAccount,
+  wdBank,
+  setWdBank,
+  wdName,
+  bankOptions,
+  isValid,
+  busy,
+  error,
+  validateBankAccount,
+  handleAdminWithdraw
+}: AdminWithdrawFormProps) {
+  return (
+    <section className={styles.cardSection} style={{ marginTop: 32 }}>
+      <h2>Withdraw Wallet</h2>
+      <form onSubmit={handleAdminWithdraw} className={styles.withdrawForm}>
+        <select value={selectedSub} onChange={e => setSelectedSub(e.target.value)}>
+          {subBalances.map(s => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          placeholder="Amount"
+          value={wdAmount}
+          onChange={e => setWdAmount(e.target.value)}
+          required
+        />
+        <div style={{ minWidth: 160 }}>
+          <Select
+            options={bankOptions}
+            value={bankOptions.find(o => o.value === wdBank) || null}
+            onChange={opt => setWdBank(opt?.value || '')}
+            placeholder="Select bank…"
+            isSearchable
+            styles={{
+              container: b => ({ ...b, width: '100%' }),
+              control: b => ({ ...b, minHeight: '2.5rem' })
+            }}
+          />
+        </div>
+        <input
+          type="text"
+          placeholder="Account No"
+          value={wdAccount}
+          onChange={e => setWdAccount(e.target.value)}
+          required
+        />
+        <div className={styles.readonlyWrapper}>
+          <input readOnly placeholder="Account Name" value={wdName} />
+          {isValid && <CheckCircle className={styles.validIcon} size={18} />}
+        </div>
+        <button type="button" onClick={validateBankAccount} disabled={busy.validating}>
+          {busy.validating ? 'Validating…' : 'Validate'}
+        </button>
+        <button type="submit" disabled={!isValid || !!error || busy.submitting}>
+          {busy.submitting ? 'Submitting…' : 'Withdraw'}
+        </button>
+        {error && <span className={styles.error}>{error}</span>}
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/WithdrawalHistory.tsx
+++ b/frontend/src/components/dashboard/WithdrawalHistory.tsx
@@ -1,0 +1,111 @@
+import { Withdrawal } from '@/types/dashboard'
+import styles from '@/pages/Dashboard.module.css'
+
+interface WithdrawalHistoryProps {
+  loadingWd: boolean
+  withdrawals: Withdrawal[]
+}
+
+export default function WithdrawalHistory({ loadingWd, withdrawals }: WithdrawalHistoryProps) {
+  return (
+    <section className={styles.tableSection} style={{ marginTop: 32 }}>
+      <h2>Withdrawal History</h2>
+      {loadingWd ? (
+        <div className={styles.loader}>Loading withdrawals…</div>
+      ) : (
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Ref ID</th>
+                <th>Account Name</th>
+                <th>Alias</th>
+                <th>Account No.</th>
+                <th>Bank Code</th>
+                <th>Bank Name</th>
+                <th>Branch</th>
+                <th>Wallet/Submerchant</th>
+                <th>Withdrawal Fee</th>
+                <th>Amount</th>
+                <th>Net Amount</th>
+                <th>PG Fee</th>
+                <th>PG Trx ID</th>
+                <th>In Process</th>
+                <th>Status</th>
+                <th>Completed At</th>
+              </tr>
+            </thead>
+            <tbody>
+              {withdrawals.length ? (
+                withdrawals.map(w => (
+                  <tr key={w.id}>
+                    <td>
+                      {new Date(w.createdAt).toLocaleString('id-ID', {
+                        dateStyle: 'short',
+                        timeStyle: 'short'
+                      })}
+                    </td>
+                    <td>{w.refId}</td>
+                    <td>{w.accountName}</td>
+                    <td>{w.accountNameAlias}</td>
+                    <td>{w.accountNumber}</td>
+                    <td>{w.bankCode}</td>
+                    <td>{w.bankName}</td>
+                    <td>{w.branchName ?? '-'}</td>
+                    <td>{w.wallet}</td>
+                    <td>
+                      {(w.amount - (w.netAmount ?? 0)).toLocaleString('id-ID', {
+                        style: 'currency',
+                        currency: 'IDR'
+                      })}
+                    </td>
+                    <td>
+                      {w.amount.toLocaleString('id-ID', {
+                        style: 'currency',
+                        currency: 'IDR'
+                      })}
+                    </td>
+                    <td>
+                      {w.netAmount != null
+                        ? w.netAmount.toLocaleString('id-ID', {
+                            style: 'currency',
+                            currency: 'IDR'
+                          })
+                        : '-'}
+                    </td>
+                    <td>
+                      {w.pgFee != null
+                        ? w.pgFee.toLocaleString('id-ID', {
+                            style: 'currency',
+                            currency: 'IDR'
+                          })
+                        : '-'}
+                    </td>
+                    <td>{w.paymentGatewayId ?? '-'}</td>
+                    <td>{w.isTransferProcess ? 'Yes' : 'No'}</td>
+                    <td>{w.status}</td>
+                    <td>
+                      {w.completedAt
+                        ? new Date(w.completedAt).toLocaleString('id-ID', {
+                            dateStyle: 'short',
+                            timeStyle: 'short'
+                          })
+                        : '-'}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={17} className={styles.noData}>
+                    No withdrawals
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,0 +1,45 @@
+export type Tx = {
+  id: string
+  date: string
+  rrn: string
+  playerId: string
+  amount: number
+  feeLauncx: number
+  feePg: number
+  netSettle: number
+  status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID'
+  settlementStatus: string
+  channel: string
+  paymentReceivedTime?: string
+  settlementTime?: string
+  trxExpirationTime?: string
+}
+
+export interface Withdrawal {
+  id: string
+  refId: string
+  accountName: string
+  accountNameAlias: string
+  accountNumber: string
+  bankCode: string
+  bankName: string
+  branchName?: string
+  amount: number
+  withdrawFeePercent: number
+  withdrawFeeFlat: number
+  pgFee?: number
+  netAmount?: number
+  paymentGatewayId?: string
+  isTransferProcess: boolean
+  status: string
+  createdAt: string
+  completedAt?: string
+  wallet: string
+}
+
+export type SubBalance = {
+  id: string
+  name: string
+  provider: string
+  balance: number
+}


### PR DESCRIPTION
## Summary
- modularize dashboard by moving transaction table, withdrawal history, and admin withdraw form to dedicated components
- load heavy dashboard components lazily with `next/dynamic`
- centralize dashboard-related types for reuse

## Testing
- `npm test`
- `cd frontend && npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890de079a688328a07b7f3511db6d20