### PR TITLE
feat: add otp support to admin withdraw

### DIFF
--- a/frontend/src/components/dashboard/AdminWithdrawForm.tsx
+++ b/frontend/src/components/dashboard/AdminWithdrawForm.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
 import Select from 'react-select'
 import { CheckCircle } from 'lucide-react'
+import api from '@/lib/api'
 import { SubBalance } from '@/types/dashboard'
 import styles from '@/pages/Dashboard.module.css'
 
@@ -14,6 +16,8 @@ interface AdminWithdrawFormProps {
   wdBank: string
   setWdBank: (v: string) => void
   wdName: string
+  otp: string
+  setOtp: (v: string) => void
   bankOptions: { value: string; label: string }[]
   isValid: boolean
   busy: { validating: boolean; submitting: boolean }
@@ -33,6 +37,8 @@ export default function AdminWithdrawForm({
   wdBank,
   setWdBank,
   wdName,
+  otp,
+  setOtp,
   bankOptions,
   isValid,
   busy,
@@ -40,6 +46,14 @@ export default function AdminWithdrawForm({
   validateBankAccount,
   handleAdminWithdraw
 }: AdminWithdrawFormProps) {
+  const [requiresOtp, setRequiresOtp] = useState(false)
+
+  useEffect(() => {
+    api
+      .get('/admin/2fa/status')
+      .then(res => setRequiresOtp(res.data.totpEnabled))
+      .catch(() => {})
+  }, [])
   return (
     <section className={styles.cardSection} style={{ marginTop: 32 }}>
       <h2>Withdraw Wallet</h2>
@@ -85,6 +99,15 @@ export default function AdminWithdrawForm({
         <button type="button" onClick={validateBankAccount} disabled={busy.validating}>
           {busy.validating ? 'Validating…' : 'Validate'}
         </button>
+        {requiresOtp && (
+          <input
+            type="text"
+            placeholder="OTP"
+            value={otp}
+            onChange={e => setOtp(e.target.value)}
+            required
+          />
+        )}
         <button type="submit" disabled={!isValid || !!error || busy.submitting}>
           {busy.submitting ? 'Submitting…' : 'Withdraw'}
         </button>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -84,6 +84,7 @@ const [wdAmount, setWdAmount] = useState('')
 const [wdAccount, setWdAccount] = useState('')
 const [wdBank, setWdBank] = useState('')
 const [wdName, setWdName] = useState('')
+const [otp, setOtp] = useState('')
 const [banks, setBanks] = useState<{ code: string; name: string }[]>([])
 const bankOptions = banks.map(b => ({ value: b.code, label: b.name }))
 const [isValid, setIsValid] = useState(false)
@@ -350,11 +351,13 @@ async function handleAdminWithdraw(e: React.FormEvent) {
       bank_code: wdBank,
       account_number: wdAccount,
       account_name: wdName,
+      otp,
     })
     setWdAmount('')
     setWdAccount('')
     setWdBank('')
     setWdName('')
+    setOtp('')
     setIsValid(false)
 
   } catch (err: any) {
@@ -588,6 +591,8 @@ const filtered = mapped.filter(t => {
     wdBank={wdBank}
     setWdBank={setWdBank}
     wdName={wdName}
+    otp={otp}
+    setOtp={setOtp}
     bankOptions={bankOptions}
     isValid={isValid}
     busy={busy}

--- a/test/adminWithdraw.routes.test.ts
+++ b/test/adminWithdraw.routes.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+import { authenticator } from 'otplib'
+
+import { adminWithdraw } from '../src/controller/admin/merchant.controller'
+import { prisma } from '../src/core/prisma'
+import * as adminLog from '../src/util/adminLog'
+import * as oyModule from '../src/service/oyClient'
+
+const secret = authenticator.generateSecret()
+
+;(prisma as any).partnerUser = {
+  findUnique: async () => ({ totpEnabled: true, totpSecret: secret })
+}
+;(prisma as any).setting = { findUnique: async () => ({ value: null }) }
+;(prisma as any).sub_merchant = {
+  findUnique: async () => ({ credentials: { merchantId: 'm', secretKey: 'k' }, provider: 'oy' })
+}
+;(prisma as any).$transaction = async (fn: any) => {
+  return fn({
+    order: { aggregate: async () => ({ _sum: { settlementAmount: 100000 } }) },
+    withdrawRequest: { aggregate: async () => ({ _sum: { amount: 0 } }) },
+    adminWithdraw: {
+      aggregate: async () => ({ _sum: { amount: 0 } }),
+      create: async () => {}
+    }
+  })
+}
+;(prisma as any).adminWithdraw = { update: async () => {} }
+;(adminLog as any).logAdminAction = async () => {}
+
+;(oyModule as any).OyClient = class {
+  async disburse() {
+    return { status: { code: '101' }, trx_id: 'trx' }
+  }
+}
+
+const app = express()
+app.use(express.json())
+app.post('/withdraw', (req, res) => {
+  ;(req as any).userId = 'admin1'
+  adminWithdraw(req as any, res)
+})
+
+const basePayload = {
+  subMerchantId: 'sub1',
+  amount: 1000,
+  bank_code: '001',
+  account_number: '123',
+  account_name: 'Test'
+}
+
+test('withdraw fails without otp', async () => {
+  const res = await request(app).post('/withdraw').send(basePayload)
+  assert.equal(res.status, 400)
+  assert.equal(res.body.error, 'OTP wajib diisi')
+})
+
+test('withdraw fails with invalid otp', async () => {
+  const res = await request(app).post('/withdraw').send({ ...basePayload, otp: '123456' })
+  assert.equal(res.status, 400)
+  assert.equal(res.body.error, 'OTP tidak valid')
+})
+
+test('withdraw succeeds with valid otp', async () => {
+  const otp = authenticator.generate(secret)
+  const res = await request(app).post('/withdraw').send({ ...basePayload, otp })
+  assert.equal(res.status, 201)
+  assert.deepEqual(res.body, { status: 'PENDING' })
+})


### PR DESCRIPTION
## Summary
- add OTP state to admin dashboard withdraw form and send it with withdrawals
- extend AdminWithdrawForm with conditional OTP input driven by 2FA status
- cover withdraw OTP validation with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ee33adc88328af05c6b83af93d6d