### PR TITLE
Allow super admins to access client routes

### DIFF
--- a/src/route/admin/client.routes.ts
+++ b/src/route/admin/client.routes.ts
@@ -5,9 +5,10 @@ import * as ctrl from '../../controller/admin/client.controller'
 
 const router = Router()
 
-// semua route hanya untuk ADMIN
+// semua route hanya untuk ADMIN & SUPER_ADMIN
 router.use(authMiddleware, (req, res, next) => {
-  if ((req as any).userRole !== 'ADMIN') return res.status(403).end()
+  const role = (req as any).userRole
+  if (role !== 'ADMIN' && role !== 'SUPER_ADMIN') return res.status(403).end()
   next()
 })
 


### PR DESCRIPTION
## Summary
- allow `SUPER_ADMIN` role to access admin client routes

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_6890fffb6f8483288fa333b25caa540e