### PR TITLE
feat: separate wallet balance endpoint

### DIFF
--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -25,6 +25,8 @@ router.post('/',    ctrl.createMerchant)
 router.get('/',     ctrl.getAllMerchants)
 router.get('/allclient',     ctrl.getAllClient)
 
+router.get('/:merchantId/balances', ctrl.getMerchantBalances)
+
 router.get('/:id',  ctrl.getMerchantById)
 router.patch('/:id',      ctrl.updateMerchant)
 router.patch('/:id/fee',  ctrl.setFeeRate)


### PR DESCRIPTION
## Summary
- add `/admin/merchants/:merchantId/balances` endpoint serving cached sub-wallet balances
- refactor dashboard summary to exclude wallet balances
- frontend loads balances separately with placeholder while fetching

## Testing
- `npm test` *(fails: test/ipWhitelist.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6891093a8bbc8328a2bcf662861af378