### PR TITLE
feat(frontend): adjust dashboard balance loader

### DIFF
--- a/frontend/src/pages/Dashboard.module.css
+++ b/frontend/src/pages/Dashboard.module.css
@@ -14,6 +14,14 @@
   font-size: 1.25rem;
 }
 
+.cardLoader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4b5563;
+  font-size: 1.25rem;
+}
+
 /* ==== FILTER BAR ====================================================== */
 .filters {
   display: flex;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -595,7 +595,9 @@ const filtered = mapped.filter(t => {
 <section className={styles.cardSection} style={{ marginTop: 32 }}>
   <h2>Wallet Balances</h2>
   {loadingBalances ? (
-    <div className={styles.loader}>Loading balances…</div>
+    <div className={styles.statsGrid}>
+      <div className={`${styles.card} ${styles.cardLoader}`}>Loading balances…</div>
+    </div>
   ) : (
     <div className={styles.statsGrid}>
       {subBalances.map(s => (


### PR DESCRIPTION
## Summary
- display wallet balance loader within stats grid to avoid full-page height
- add cardLoader styles for centered loading indicator

## Testing
- `npm test` (fails: test/ipWhitelist.routes.test.ts)
- `cd frontend && npm run lint` (fails: prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68911af360348328b5dd1c247199ea7b