### PR TITLE
feat: add global date range filter

### DIFF
--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -1,21 +1,10 @@
 import { Dispatch, SetStateAction } from 'react'
-import DatePicker from 'react-datepicker'
-import 'react-datepicker/dist/react-datepicker.css'
 import { FileText, ClipboardCopy } from 'lucide-react'
 import api from '@/lib/api'
 import styles from '@/pages/Dashboard.module.css'
 import { Tx } from '@/types/dashboard'
 
-type Range = 'today' | 'yesterday' | 'week' | 'month' | 'custom'
-
 interface TransactionsTableProps {
-  range: Range
-  setRange: Dispatch<SetStateAction<Range>>
-  dateRange: [Date | null, Date | null]
-  setDateRange: Dispatch<SetStateAction<[Date | null, Date | null]>>
-  startDate: Date | null
-  endDate: Date | null
-  applyDateRange: () => void
   search: string
   setSearch: Dispatch<SetStateAction<string>>
   statusFilter: string
@@ -31,13 +20,6 @@ interface TransactionsTableProps {
 }
 
 export default function TransactionsTable({
-  range,
-  setRange,
-  dateRange,
-  setDateRange,
-  startDate,
-  endDate,
-  applyDateRange,
   search,
   setSearch,
   statusFilter,
@@ -54,49 +36,6 @@ export default function TransactionsTable({
   return (
     <>
       <section className={styles.filters}>
-        <div className={styles.rangeControls}>
-          <select value={range} onChange={e => setRange(e.target.value as Range)}>
-            <option value="today">Hari ini</option>
-            <option value="yesterday">Kemarin</option>
-            <option value="week">7 Hari Terakhir</option>
-            <option value="month">30 Hari Terakhir</option>
-            <option value="custom">Custom</option>
-          </select>
-          {range === 'custom' && (
-            <div className={styles.customDatePicker}>
-              <DatePicker
-                selectsRange
-                startDate={startDate}
-                endDate={endDate}
-                onChange={upd => setDateRange(upd)}
-                isClearable={false}
-                placeholderText="Select Date Range…"
-                maxDate={new Date()}
-                dateFormat="dd-MM-yyyy"
-                className={styles.dateInput}
-              />
-              {(startDate || endDate) && (
-                <button
-                  type="button"
-                  className={styles.clearRangeBtn}
-                  onClick={() => {
-                    setDateRange([null, null])
-                  }}
-                >
-                  Clear
-                </button>
-              )}
-              <button
-                type="button"
-                className={styles.applyBtn}
-                onClick={applyDateRange}
-                disabled={!startDate || !endDate}
-              >
-                Terapkan
-              </button>
-            </div>
-          )}
-        </div>
         <input
           type="text"
           className={styles.searchInput}

--- a/frontend/src/pages/Dashboard.module.css
+++ b/frontend/src/pages/Dashboard.module.css
@@ -283,6 +283,8 @@
 .childSelector {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: .75rem;
   margin-bottom: 1rem;
   font-family: Inter, sans-serif;
 }
@@ -408,5 +410,9 @@
     outline: none;
     border-color: #666;
     box-shadow: 0 0 0 3px rgba(100,100,255,0.2);
+  }
+  .childSelector {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -7,6 +7,8 @@ import { Wallet, ListChecks, Clock, Layers } from 'lucide-react'
 import styles from './Dashboard.module.css'
 import dynamic from 'next/dynamic'
 import { Tx, Withdrawal, SubBalance } from '@/types/dashboard'
+import DatePicker from 'react-datepicker'
+import 'react-datepicker/dist/react-datepicker.css'
 
 function parseJwt(t: string) {
   try {
@@ -524,7 +526,7 @@ const filtered = mapped.filter(t => {
 
   return (
     <div className={styles.container}>
-      {/* Merchant selector */}
+      {/* Merchant selector & range filter */}
       <div className={styles.childSelector}>
         <label>Client:</label>
         <select
@@ -536,6 +538,50 @@ const filtered = mapped.filter(t => {
             <option key={m.id} value={m.id}>{m.name}</option>
           ))}
         </select>
+
+        <select
+          value={range}
+          onChange={e => setRange(e.target.value as typeof range)}
+        >
+          <option value="today">Hari ini</option>
+          <option value="yesterday">Kemarin</option>
+          <option value="week">7 Hari Terakhir</option>
+          <option value="month">30 Hari Terakhir</option>
+          <option value="custom">Custom</option>
+        </select>
+
+        {range === 'custom' && (
+          <div className={styles.customDatePicker}>
+            <DatePicker
+              selectsRange
+              startDate={startDate}
+              endDate={endDate}
+              onChange={upd => setDateRange(upd)}
+              isClearable={false}
+              placeholderText="Select Date Range…"
+              maxDate={new Date()}
+              dateFormat="dd-MM-yyyy"
+              className={styles.dateInput}
+            />
+            {(startDate || endDate) && (
+              <button
+                type="button"
+                className={styles.clearRangeBtn}
+                onClick={() => setDateRange([null, null])}
+              >
+                Clear
+              </button>
+            )}
+            <button
+              type="button"
+              className={styles.applyBtn}
+              onClick={applyDateRange}
+              disabled={!startDate || !endDate}
+            >
+              Terapkan
+            </button>
+          </div>
+        )}
       </div>
 <aside className={styles.sidebar}>
   <section className={styles.statsGrid}>
@@ -671,13 +717,6 @@ const filtered = mapped.filter(t => {
       <main className={styles.content}>
 
           <TransactionsTable
-            range={range}
-            setRange={setRange}
-            dateRange={dateRange}
-            setDateRange={setDateRange}
-            startDate={startDate}
-            endDate={endDate}
-            applyDateRange={applyDateRange}
             search={search}
             setSearch={setSearch}
             statusFilter={statusFilter}


### PR DESCRIPTION
## Summary
- add date range selector with custom picker to dashboard header
- style child selector for new range controls and responsiveness
- simplify transactions table filters to rely on global date range

## Testing
- `npm test` (fails: test/ipWhitelist.routes.test.ts)
- `cd frontend && npm run lint` (prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68913ceaf17c83289948352e7823d7f9