### PR TITLE
feat: add withdraw filter styles

### DIFF
--- a/frontend/src/components/dashboard/WithdrawalHistory.tsx
+++ b/frontend/src/components/dashboard/WithdrawalHistory.tsx
@@ -35,7 +35,7 @@ export default function WithdrawalHistory({ loadingWd, withdrawals }: Withdrawal
 
   return (
     <>
-      <section className={styles.filters}>
+      <section className={styles.withdrawFilters}>
         <input
           type="text"
           placeholder="Search Ref"
@@ -69,7 +69,6 @@ export default function WithdrawalHistory({ loadingWd, withdrawals }: Withdrawal
           placeholderText="Select Date Range..."
           maxDate={new Date()}
           dateFormat="dd-MM-yyyy"
-          className={styles.searchInput}
         />
       </section>
       <section className={styles.tableSection} style={{ marginTop: 32 }}>

--- a/frontend/src/pages/Dashboard.module.css
+++ b/frontend/src/pages/Dashboard.module.css
@@ -30,6 +30,30 @@
   align-items: center;
   margin-bottom: 1.5rem;
 }
+.withdrawFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.withdrawFilters input,
+.withdrawFilters select {
+  padding: .5rem .75rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: .5rem;
+  font-size: .875rem;
+  font-family: var(--font-sans, sans-serif);
+  flex: 1 1 150px;
+}
+@media (max-width: 480px) {
+  .withdrawFilters {
+    flex-direction: column;
+  }
+  .withdrawFilters input,
+  .withdrawFilters select {
+    width: 100%;
+  }
+}
 .rangeControls {
   display: flex;
   gap: .75rem;

--- a/frontend/src/pages/admin/clients/[clientId]/withdraw.tsx
+++ b/frontend/src/pages/admin/clients/[clientId]/withdraw.tsx
@@ -130,15 +130,13 @@ const AdminClientWithdrawPage: NextPage & { disableLayout?: boolean } = () => {
             </button>
           </div>
 
-          <div className={styles.filters}>
+          <div className={styles.withdrawFilters}>
             <input
-              className={styles.input}
               placeholder="Search Ref"
               value={searchRef}
               onChange={e => { setSearchRef(e.target.value); setPage(1) }}
             />
             <select
-              className={styles.select}
               value={statusFilter}
               onChange={e => { setStatusFilter(e.target.value); setPage(1) }}
             >
@@ -161,7 +159,6 @@ const AdminClientWithdrawPage: NextPage & { disableLayout?: boolean } = () => {
               placeholderText="Select Date Range..."
               maxDate={new Date()}
               dateFormat="dd-MM-yyyy"
-              className={styles.input}
             />
           </div>
 

--- a/frontend/src/pages/client/WithdrawPage.module.css
+++ b/frontend/src/pages/client/WithdrawPage.module.css
@@ -106,6 +106,30 @@
 .exportBtn:hover{ background:#4f46e5; }
 
 .filters    { display:flex; flex-wrap:wrap; gap:.75rem; margin-bottom:1rem; }
+.withdrawFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.withdrawFilters input,
+.withdrawFilters select {
+  padding: .5rem .75rem;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  font-size: .875rem;
+  font-family: var(--font-sans, sans-serif);
+  flex: 1 1 150px;
+}
+@media (max-width: 480px) {
+  .withdrawFilters {
+    flex-direction: column;
+  }
+  .withdrawFilters input,
+  .withdrawFilters select {
+    width: 100%;
+  }
+}
 .input,.select { padding:.5rem .75rem; border:1px solid #d1d5db; border-radius:8px;
                  font-size:.875rem; }
 

--- a/frontend/src/pages/client/withdraw.tsx
+++ b/frontend/src/pages/client/withdraw.tsx
@@ -428,15 +428,13 @@ if (endDate   && d > new Date(endDate.setHours(23,59,59))) return false
           </button>
         </div>
 
-     <div className={styles.filters}>
+    <div className={styles.withdrawFilters}>
   <input
-    className={styles.input}
     placeholder="Search Ref"
     value={searchRef}
     onChange={e => { setSearchRef(e.target.value); setPage(1) }}
   />
   <select
-    className={styles.select}
     value={statusFilter}
     onChange={e => { setStatusFilter(e.target.value); setPage(1) }}
   >
@@ -464,7 +462,6 @@ if (endDate   && d > new Date(endDate.setHours(23,59,59))) return false
     placeholderText="Select Date Range..."
     maxDate={new Date()}
     dateFormat="dd-MM-yyyy"
-    className={styles.input}
   />
 </div>
 


### PR DESCRIPTION
## Summary
- add withdrawFilters class for flexible filter layout
- use new filter styling in withdrawal history and admin/client pages

## Testing
- `npm test` *(fails: test/ipWhitelist.routes.test.ts: test failed)*
- `npm --prefix frontend run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6891bb88d5b08328b2bd9de0724f856f