### PR TITLE
Reset pagination on filter change

### DIFF
--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -46,9 +46,18 @@ export default function TransactionsTable({
           className={styles.searchInput}
           placeholder="Cari TRX ID, RRN, atau Player ID…"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => {
+            setPage(1)
+            setSearch(e.target.value)
+          }}
         />
-        <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+        <select
+          value={statusFilter}
+          onChange={e => {
+            setPage(1)
+            setStatusFilter(e.target.value)
+          }}
+        >
           <option value="PAID">PAID</option>
           <option value="PENDING">PENDING</option>
           <option value="EXPIRED">EXPIRED</option>


### PR DESCRIPTION
## Summary
- Reset transaction table page to 1 when search or status filter changes

## Testing
- `npm test` (fails: ipWhitelist routes test)
- `npm run lint` (frontend prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_6891c157bea88328ae577e8e0d6e95d3