### PR TITLE
style(dashboard): add spacing before withdrawal history

### DIFF
--- a/frontend/src/pages/Dashboard.module.css
+++ b/frontend/src/pages/Dashboard.module.css
@@ -54,6 +54,9 @@
     width: 100%;
   }
 }
+.withdrawSection {
+  margin-top: 2rem;
+}
 .rangeControls {
   display: flex;
   gap: .75rem;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -757,9 +757,9 @@ const filtered = mapped.filter(t => {
             buildParams={buildParams}
             onDateChange={handleDateChange}
           />
-
-
-      <WithdrawalHistory loadingWd={loadingWd} withdrawals={withdrawals} />
+      <section className={styles.withdrawSection}>
+        <WithdrawalHistory loadingWd={loadingWd} withdrawals={withdrawals} />
+      </section>
             {/* === ADMIN WITHDRAWAL HISTORY ======================================= */}
       {isSuperAdmin && (
         <section className={styles.tableSection} style={{ marginTop: 32 }}>


### PR DESCRIPTION
## Summary
- wrap `WithdrawalHistory` in a section to add margin-top
- add `.withdrawSection` class to Dashboard styles for consistent spacing

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet; JWT_SECRET environment variable is required)*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(aborted: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6891c13c59488328bf7fb0a22c67cc5a