### PR TITLE
feat: notify settlement start

### DIFF
--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -7,6 +7,7 @@ import { prisma } from '../core/prisma'
 import { config } from '../config'
 import crypto from 'crypto'
 import logger from '../logger'
+import { sendTelegramMessage } from '../core/telegram.axios'
 
 // ————————— CONFIG —————————
 const BATCH_SIZE = 1000                          // jumlah order PAID diproses per batch
@@ -265,6 +266,14 @@ export function scheduleSettlementChecker() {
         lastCreatedAt = null;
         lastId        = null;
         logger.info('[SettlementCron] 🔄 Reset cursor & set cut‑off at ' + cutoffTime.toISOString());
+        try {
+          await sendTelegramMessage(
+            config.api.telegram.adminChannel,
+            `[SettlementCron] Starting settlement check at ${cutoffTime.toISOString()}`
+          );
+        } catch (err) {
+          logger.error('[SettlementCron] Failed to send Telegram notification:', err);
+        }
         await safeRun();
       },
       { timezone: 'Asia/Jakarta' }


### PR DESCRIPTION
## Summary
- send Telegram notification when 17:00 settlement job starts

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef5cb59083288445a4078a9dae27