### PR TITLE
feat: make settlement max batches configurable

### DIFF
--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -221,7 +221,8 @@ const where: any = {
 // safe runner untuk batch loop dengan limit
 async function processBatchLoop() {
   let batches = 0;
-  const MAX_BATCHES = 10;
+  const MAX_BATCHES = Math.min(Number(process.env.SETTLEMENT_MAX_BATCHES) || 50, 100);
+  // env SETTLEMENT_MAX_BATCHES defaults to 50 and is capped at 100 to avoid resource exhaustion
   while (running && batches < MAX_BATCHES && (await processBatchOnce())) {
     batches++;
     logger.info(`[SettlementCron] ✅ Batch #${batches} complete at ${new Date().toISOString()}`);


### PR DESCRIPTION
## Summary
- make settlement cron batch limit configurable via SETTLEMENT_MAX_BATCHES env
- prevent excessive processing by capping batches at 100

## Testing
- `npm test` *(fails: test/ipWhitelist.routes.test.ts test failing: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6891f2c623148328b4d6158d80ca05bc