### PR TITLE
feat: add manual settlement trigger progress

### DIFF
--- a/frontend/src/pages/admin/manual-trigger.tsx
+++ b/frontend/src/pages/admin/manual-trigger.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import api from '@/lib/api'
+import { useRequireAuth } from '@/hooks/useAuth'
+
+interface Status {
+  running: boolean
+  current: number
+  total: number
+  settledOrders: number
+  netAmount: number
+  done: boolean
+  error?: string
+}
+
+export default function ManualTriggerPage() {
+  useRequireAuth()
+  const [status, setStatus] = useState<Status>({
+    running: false,
+    current: 0,
+    total: 0,
+    settledOrders: 0,
+    netAmount: 0,
+    done: false
+  })
+  const pollRef = useRef<NodeJS.Timer | null>(null)
+
+  const start = async () => {
+    try {
+      await api.post('/admin/settlement/run')
+      setStatus(s => ({ ...s, running: true, done: false, error: undefined }))
+      pollRef.current = setInterval(async () => {
+        try {
+          const r = await api.get<Status>('/admin/settlement/status')
+          setStatus(r.data)
+          if (r.data.done) {
+            clearInterval(pollRef.current!)
+            pollRef.current = null
+          }
+        } catch (e: any) {
+          clearInterval(pollRef.current!)
+          pollRef.current = null
+          setStatus(s => ({ ...s, running: false, error: 'Failed to fetch status' }))
+        }
+      }, 1000)
+    } catch (e: any) {
+      setStatus(s => ({ ...s, running: false, error: 'Failed to start process' }))
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [])
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Manual Settlement Trigger</h1>
+      {status.error && <div className="text-red-600">{status.error}</div>}
+      <button
+        onClick={start}
+        disabled={status.running}
+        className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+      >
+        {status.running ? 'Running…' : 'Run Settlement'}
+      </button>
+      {status.running && (
+        <div className="space-y-2">
+          <progress value={status.current} max={status.total || 1} className="w-full" />
+          <p>
+            Batch {status.current}/{status.total} – Settled {status.settledOrders} orders, Net {status.netAmount}
+          </p>
+        </div>
+      )}
+      {status.done && !status.error && (
+        <div className="text-green-700">
+          Completed: settled {status.settledOrders} orders, net amount {status.netAmount}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import adminClientUserRoutes from './route/admin/clientUser.routes';
 import adminTotpRoutes from './route/admin/totp.routes';
 import adminLogRoutes from './route/admin/log.routes';
 import adminIpWhitelistRoutes from './route/admin/ipWhitelist.routes';
+import adminSettlementRoutes from './route/admin/settlement.routes';
 
 import usersRoutes from './route/users.routes';
 
@@ -142,6 +143,7 @@ app.use('/api/v1/admin/settings', authMiddleware, settingsRoutes);
 app.use('/api/v1/admin/2fa', adminTotpRoutes);
 app.use('/api/v1/admin/logs', adminLogRoutes);
 app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
+app.use('/api/v1/admin/settlement', adminSettlementRoutes);
 
 /* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
 app.use('/api/v1/client', clientWebRoutes);

--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express'
+import { runSettlementManual } from '../../cron/settlement'
+
+interface Progress {
+  running: boolean
+  current: number
+  total: number
+  settledOrders: number
+  netAmount: number
+  done: boolean
+  error?: string
+}
+
+let progress: Progress = {
+  running: false,
+  current: 0,
+  total: 0,
+  settledOrders: 0,
+  netAmount: 0,
+  done: false,
+}
+
+export async function run(req: Request, res: Response) {
+  if (progress.running) return res.status(400).json({ message: 'Settlement already running' })
+  progress = { running: true, current: 0, total: 0, settledOrders: 0, netAmount: 0, done: false }
+  res.json({ started: true })
+
+  try {
+    await runSettlementManual(info => {
+      progress.current = info.batch
+      progress.total = info.total
+      progress.settledOrders = info.settledOrders
+      progress.netAmount = info.netAmount
+    })
+    progress.running = false
+    progress.done = true
+  } catch (err: any) {
+    progress.running = false
+    progress.done = true
+    progress.error = err?.message || 'unknown error'
+  }
+}
+
+export function status(req: Request, res: Response) {
+  res.json(progress)
+}

--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { requireAdminAuth } from '../../middleware/auth'
+import { run, status } from '../../controller/admin/settlement.controller'
+
+const r = Router()
+
+r.use(requireAdminAuth)
+
+r.post('/run', run)
+r.get('/status', status)
+
+export default r


### PR DESCRIPTION
## Summary
- add manual settlement trigger page with progress polling and summary
- expose settlement run and status endpoints for per-batch stats

## Testing
- `npm test` (fails: test/ipWhitelist.routes.test.ts)


------
https://chatgpt.com/codex/tasks/task_e_68920e0a9e8c83289a86df211a8806eb