### PR TITLE
feat: add balance reconciliation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node dist/app.js",
     "dev": "ts-node src/app.ts",
     "callback-worker": "ts-node src/worker/callbackQueue.ts",
+    "reconcile-balances": "ts-node --transpile-only scripts/reconcileBalances.ts",
     "test": "node --test -r ts-node/register test/**/*.test.ts"
   },
   "author": "",

--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,15 @@ Super Admins can restrict certain administrative actions to specific IP addresse
 The whitelist is stored in the `Setting` table under the key `admin_ip_whitelist`.
 If the setting is missing or empty, no IP restriction is applied.
 
+## Reconcile Partner Balances
+
+This script recalculates `PartnerClient` balances based on settled orders and
+pending/completed withdrawals.
+
+```
+npm run reconcile-balances
+```
+
+Make sure database environment variables are set before running the script. The
+script prints a summary of balance adjustments to the console.
+

--- a/scripts/reconcileBalances.ts
+++ b/scripts/reconcileBalances.ts
@@ -1,0 +1,61 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import { PrismaClient, DisbursementStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface BalanceSummary {
+  clientId: string;
+  oldBalance: number;
+  totalSettlement: number;
+  totalWithdraw: number;
+  newBalance: number;
+}
+
+async function reconcileBalances(): Promise<void> {
+  const clients = await prisma.partnerClient.findMany();
+  const summaries: BalanceSummary[] = [];
+
+  for (const client of clients) {
+    const settlementAgg = await prisma.order.aggregate({
+      _sum: { settlementAmount: true },
+      where: { partnerClientId: client.id, settlementTime: { not: null } },
+    });
+    const totalSettlement = settlementAgg._sum.settlementAmount ?? 0;
+
+    const withdrawAgg = await prisma.withdrawRequest.aggregate({
+      _sum: { amount: true },
+      where: {
+        partnerClientId: client.id,
+        status: { in: [DisbursementStatus.PENDING, DisbursementStatus.COMPLETED] },
+      },
+    });
+    const totalWithdraw = withdrawAgg._sum.amount ?? 0;
+
+    const newBalance = totalSettlement - totalWithdraw;
+
+    await prisma.partnerClient.update({
+      where: { id: client.id },
+      data: { balance: newBalance },
+    });
+
+    summaries.push({
+      clientId: client.id,
+      oldBalance: client.balance,
+      totalSettlement,
+      totalWithdraw,
+      newBalance,
+    });
+  }
+
+  console.table(summaries);
+}
+
+reconcileBalances()
+  .catch((err) => {
+    console.error('Error reconciling balances:', err);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add script to recalculate partner balances from settled orders and withdrawals
- expose script via npm run reconcile-balances
- document how to run the reconciliation script

## Testing
- `npm test` *(fails: @prisma/client did not initialize; JWT_SECRET env var missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894413157388328a7e6efe7d56c7c3b