### PR TITLE
feat: add client balance reconciliation

### DIFF
--- a/frontend/src/pages/admin/clients/[clientId]/dashboard.tsx
+++ b/frontend/src/pages/admin/clients/[clientId]/dashboard.tsx
@@ -122,6 +122,16 @@ const AdminClientDashboard = () => {
     }
   }
 
+  const reconcileBalance = async () => {
+    if (!clientId) return
+    try {
+      await api.post(`/admin/clients/${clientId}/reconcile-balance`)
+      fetchSummary()
+    } catch {
+      router.push('/login')
+    }
+  }
+
   useEffect(() => { fetchSummary() }, [clientId, range, selectedChild, from, to, statusFilter])
   useEffect(() => { fetchTransactions() }, [clientId, range, selectedChild, from, to, statusFilter])
   const filtered = txs.filter(t =>
@@ -153,7 +163,7 @@ const AdminClientDashboard = () => {
 
         <aside className={styles.sidebar}>
           <section className={styles.statsGrid}>
-            {/* <div className={`${styles.card} ${styles.activeBalance}`}>
+            <div className={`${styles.card} ${styles.activeBalance}`}>
               <Wallet className={styles.cardIcon} />
               <h2>
                 Active Balance
@@ -167,7 +177,8 @@ const AdminClientDashboard = () => {
                 )}
               </h2>
               <p>{balance.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}</p>
-            </div> */}
+              <button className={styles.applyBtn} onClick={reconcileBalance}>Reconcile Balance</button>
+            </div>
             <div className={styles.card}>
               <ListChecks className={styles.cardIcon} />
               <h2>Transactions</h2>

--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,11 @@ npm run reconcile-balances
 Make sure database environment variables are set before running the script. The
 script prints a summary of balance adjustments to the console.
 
+### Admin Panel Reconciliation
+
+Admins can also trigger a balance recomputation from the web panel:
+
+1. Log in to the admin panel and open a client's dashboard.
+2. Click **Reconcile Balance** inside the *Active Balance* card.
+3. The server recalculates the balance from settled orders minus withdrawals and the card refreshes with the new value.
+

--- a/src/route/admin/client.routes.ts
+++ b/src/route/admin/client.routes.ts
@@ -23,6 +23,7 @@ router.get('/providers',       ctrl.listProviders)
 router.get('/:clientId/dashboard', ctrl.getClientDashboardAdmin)
 router.get('/:clientId/withdrawals', ctrl.getClientWithdrawalsAdmin)
 router.get('/:clientId/subwallets',  ctrl.getClientSubWallets)
+router.post('/:clientId/reconcile-balance', ctrl.reconcileClientBalance)
 
 // 3) [Dihapus] Koneksi PG per client
 // Feature deprecated: fee kini ditetapkan global di PartnerClient


### PR DESCRIPTION
## Summary
- support recalculating client balances from settled orders minus withdrawals
- expose admin endpoint and button to trigger reconciliation
- document balance reconciliation flow in admin panel

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet, JWT_SECRET environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_6894450c186c83288faf64f02847b6a2