### PR TITLE
Skip settled orders on Hilogate callback

### DIFF
--- a/src/controller/payment.ts
+++ b/src/controller/payment.ts
@@ -242,9 +242,15 @@ const trxExpirationTime = full.expires_at?.value
     // 6) Ambil merchantId
     const existing = await prisma.order.findUnique({
       where: { id: orderId },
-      select: { merchantId: true }
+      select: { merchantId: true, status: true }
     })
     if (!existing) throw new Error(`Order ${orderId} not found`)
+    if (existing.status === 'SETTLED') {
+      logger.info(`[Callback] Order ${orderId} already SETTLED; skipping update`)
+      return res
+        .status(200)
+        .json(createSuccessResponse({ message: 'Order already settled' }))
+    }
     const merchantId = existing.merchantId
 
     // 7) Ambil konfigurasi fee partner


### PR DESCRIPTION
## Summary
- Avoid reprocessing callbacks for orders already SETTLED
- Include order status when loading existing order in Hilogate callback

## Testing
- `npm run generate`
- `JWT_SECRET=dummy npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948529fe9c832890d2be9a22af3331