### PR TITLE
Filter parent clients for summary groups

### DIFF
--- a/src/cron/dashboardSummary.ts
+++ b/src/cron/dashboardSummary.ts
@@ -81,6 +81,7 @@ export async function buildSummaryMessage(): Promise<string[]> {
   const groupMessages: string[] = []
 
   for (const parent of groups) {
+    if (parent.children.length === 0) continue
     const ids = [parent.id, ...parent.children.map(c => c.id)]
 
     const gTpvAgg = await prisma.order.aggregate({

--- a/src/service/partnerClient.ts
+++ b/src/service/partnerClient.ts
@@ -2,7 +2,10 @@ import { prisma } from '../core/prisma'
 
 export async function getParentClientsWithChildren() {
   return prisma.partnerClient.findMany({
-    where: { parentClientId: null },
+    where: {
+      parentClientId: null,
+      children: { some: {} },
+    },
     include: { children: true },
   })
 }


### PR DESCRIPTION
## Summary
- Only fetch parent clients that have at least one child for dashboard summary grouping
- Skip parents with no children when composing group messages

## Testing
- `npm test` (fails: @prisma/client did not initialize yet, JWT_SECRET env var required)

------
https://chatgpt.com/codex/tasks/task_e_68973f63d1c483288dc0768db8f08400