### PR TITLE
feat: include extra hilogate timestamps

### DIFF
--- a/src/service/hilogateFallback.ts
+++ b/src/service/hilogateFallback.ts
@@ -26,6 +26,18 @@ async function resendCallback(refId: string, cfg: HilogateConfig) {
         : data?.updated_at?.value
         ? new Date(data.updated_at.value)
         : wibTimestamp();
+    const settlementTime =
+      data?.settlement_time
+        ? new Date(data.settlement_time)
+        : data?.updated_at?.value
+        ? new Date(data.updated_at.value)
+        : undefined;
+    const trxExpirationTime =
+      data?.trx_expiration_time
+        ? new Date(data.trx_expiration_time)
+        : data?.expired_at
+        ? new Date(data.expired_at)
+        : undefined;
     await processHilogatePayload({
       ref_id: data.ref_id,
       amount: data.amount,
@@ -35,6 +47,8 @@ async function resendCallback(refId: string, cfg: HilogateConfig) {
       qr_string: data.qr_string,
       settlement_status: data.settlement_status,
       paymentReceivedTime,
+      settlementTime,
+      trxExpirationTime,
     });
     logger.info(`[hilogateFallback] resend processed for ${refId}`);
   } catch (err: any) {

--- a/src/service/payment.ts
+++ b/src/service/payment.ts
@@ -440,6 +440,8 @@ export async function processHilogatePayload(payload: {
   rrn?: string;
   detail?: { rrn?: string };
   paymentReceivedTime?: Date;
+  settlementTime?: Date;
+  trxExpirationTime?: Date;
 }) {
   const {
     ref_id: orderId,
@@ -451,6 +453,8 @@ export async function processHilogatePayload(payload: {
     rrn,
     detail,
     paymentReceivedTime,
+    settlementTime,
+    trxExpirationTime,
   } = payload;
   const rrnVal = rrn ?? detail?.rrn ?? null;
 
@@ -508,6 +512,9 @@ export async function processHilogatePayload(payload: {
       settlementAmount: isSuccess ? null       : net_amount,
       qrPayload:        qr_string ?? null,
       rrn:              rrnVal,
+      paymentReceivedTime,
+      settlementTime,
+      trxExpirationTime,
       updatedAt:        new Date(),
     }
   });


### PR DESCRIPTION
## Summary
- store Hilogate payment, settlement, and expiration timestamps
- pass these timestamp fields from fallback getTransaction responses

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689af53fb59083289a4ee0c084c930ba