### PR TITLE
fix: align Hilogate payload processing

### DIFF
--- a/src/service/payment.ts
+++ b/src/service/payment.ts
@@ -500,7 +500,7 @@ export async function processHilogatePayload(payload: {
     .plus(new Decimal(flatFee));
   const feeLauncxCalc = feeLauncxDec.toNumber();
   const pendingNet = grossDec.minus(feeLauncxDec).toNumber();
-  const pgFee = total_fee ?? (grossAmount - net_amount);
+  const pgFee = total_fee;
 
   // 4) Update order di DB
   await prisma.order.update({
@@ -509,15 +509,15 @@ export async function processHilogatePayload(payload: {
       status:           newStatus,
       settlementStatus: newSetSt,
       feeLauncx:        isSuccess ? feeLauncxCalc : null,
-      fee3rdParty:      pgFee ?? 0,
+      fee3rdParty:      pgFee,
       pendingAmount:    isSuccess ? pendingNet : null,
-      settlementAmount: isSuccess ? null       : net_amount,
+      settlementAmount: null,
       qrPayload:        qr_string ?? null,
       rrn:              rrnVal,
       paymentReceivedTime,
       settlementTime,
       trxExpirationTime,
-      updatedAt:        new Date(),
+      updatedAt:        wibTimestamp(),
     }
   });
 


### PR DESCRIPTION
## Summary
- align hilogate payload processing with controller logic
- always nullify settlementAmount and store total_fee for 3rd-party fee

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again; JWT_SECRET environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689afb922f188328bfb7acac7e6a0637