### PR TITLE
feat: add configurable settlement cron

### DIFF
--- a/frontend/src/pages/admin/settings.tsx
+++ b/frontend/src/pages/admin/settings.tsx
@@ -12,6 +12,7 @@ export default function SettingsPage() {
   useRequireAuth()
   const [minW, setMinW] = useState('')
   const [maxW, setMaxW] = useState('')
+  const [settlementCron, setSettlementCron] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [overrideDates, setOverrideDates] = useState<Date[]>([])
@@ -21,6 +22,7 @@ export default function SettingsPage() {
       .then(res => {
         setMinW(res.data.data.withdraw_min || '')
         setMaxW(res.data.data.withdraw_max || '')
+        setSettlementCron(res.data.data.settlement_cron || '0 16 * * *')
         const raw = res.data.data.weekend_override_dates || ''
         const dates = raw
           .split(',')
@@ -42,7 +44,8 @@ export default function SettingsPage() {
       await api.put('/admin/settings', {
         withdraw_min: minW,
         withdraw_max: maxW,
-        weekend_override_dates: datesString
+        weekend_override_dates: datesString,
+        settlement_cron: settlementCron
       })
     } catch (e: any) {
       setError(e.response?.data?.error || 'Failed to save')
@@ -84,6 +87,16 @@ export default function SettingsPage() {
             value={maxW}
             onChange={e => setMaxW(e.target.value)}
             placeholder="e.g. 500000"
+          />
+        </div>
+        <div className={styles.formGroup}>
+          <label className={styles.label}>Settlement Cron (Asia/Jakarta)</label>
+          <input
+            type="text"
+            className={styles.input}
+            value={settlementCron}
+            onChange={e => setSettlementCron(e.target.value)}
+            placeholder="e.g. 0 16 * * *"
           />
         </div>
         <div className={styles.formGroup}>

--- a/readme.md
+++ b/readme.md
@@ -71,3 +71,10 @@ Admins can also trigger a balance recomputation from the web panel:
 2. Click **Reconcile Balance** inside the *Active Balance* card.
 3. The server recalculates the balance from settled orders minus withdrawals and the card refreshes with the new value.
 
+## Settlement Cron Setting
+
+The `settlement_cron` key in the `Setting` table controls when the settlement
+job runs. It accepts a standard cron expression evaluated in the
+`Asia/Jakarta` timezone. The default expression is `0 16 * * *` (every day at
+16:00 WIB).
+

--- a/src/controller/settings.controller.ts
+++ b/src/controller/settings.controller.ts
@@ -1,18 +1,30 @@
 import { Request, Response } from 'express'
+import cron from 'node-cron'
 import { prisma } from '../core/prisma'
 import { setWeekendOverrideDates } from '../util/time'
 import { AuthRequest } from '../middleware/auth'
 import { logAdminAction } from '../util/adminLog'
+import { rescheduleSettlementCron } from '../cron/settlement'
 
 export async function getSettings(req: Request, res: Response) {
   const rows = await prisma.setting.findMany()
   const obj: Record<string,string> = {}
   rows.forEach(r => { obj[r.key] = r.value })
+  if (!obj['settlement_cron']) {
+    obj['settlement_cron'] = '0 16 * * *'
+  }
   res.json({ data: obj })
 }
 
 export async function updateSettings(req: AuthRequest, res: Response) {
   const updates: Record<string,string> = req.body
+  if (
+    updates['settlement_cron'] !== undefined &&
+    !cron.validate(updates['settlement_cron'])
+  ) {
+    return res.status(400).json({ error: 'Invalid cron expression' })
+  }
+
   const tx = await prisma.$transaction(
     Object.entries(updates).map(([key,value]) =>
       prisma.setting.upsert({
@@ -22,12 +34,15 @@ export async function updateSettings(req: AuthRequest, res: Response) {
       })
     )
   )
-    if (updates['weekend_override_dates'] !== undefined) {
+  if (updates['weekend_override_dates'] !== undefined) {
     const dates = updates['weekend_override_dates']
       .split(',')
       .map(d => d.trim())
       .filter(Boolean)
     setWeekendOverrideDates(dates)
+  }
+  if (updates['settlement_cron'] !== undefined) {
+    await rescheduleSettlementCron()
   }
   if (req.userId) {
     await logAdminAction(req.userId, 'updateSettings', 'settings', updates)

--- a/src/prisma/seed.ts
+++ b/src/prisma/seed.ts
@@ -22,6 +22,13 @@ async function main() {
     }
   });
   console.log('✅ Admin ready: admin@launcx.com / supersecret');
+
+  await prisma.setting.upsert({
+    where: { key: 'settlement_cron' },
+    update: { value: '0 16 * * *' },
+    create: { key: 'settlement_cron', value: '0 16 * * *' }
+  });
+  console.log('✅ Default settlement_cron set to 0 16 * * *');
 }
 
 main()


### PR DESCRIPTION
## Summary
- allow settlement cron expression to be stored in settings and updated via admin panel
- dynamically schedule settlement job based on `settlement_cron` with reschedule support
- add frontend input for configuring cron expression

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet; JWT_SECRET environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689aff8751e48328a5b3042e075b882e