### PR TITLE
Add settlement summary with currency formatting

### DIFF
--- a/src/core/telegram.axios.ts
+++ b/src/core/telegram.axios.ts
@@ -16,11 +16,16 @@ const telegramAxiosInstance = axios.create({
 });
 
 // Function to send a message
-const sendTelegramMessage = async (chatId : string, text : string) => {
+const sendTelegramMessage = async (
+    chatId: string,
+    text: string,
+    parseMode?: string
+) => {
     try {
         const response = await telegramAxiosInstance.post('/sendMessage', {
             chat_id: chatId,
-            text: text,
+            text,
+            ...(parseMode && { parse_mode: parseMode }),
         });
         return response.data;
     } catch (error) {


### PR DESCRIPTION
## Summary
- format settlement cron summaries with IDR currency and Jakarta time
- include failed settlement stats and send summary via Telegram with Markdown
- allow Telegram helper to accept optional parse mode

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE in test/oyCallback.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b03d661b483289c2ada07109580a7