### PR TITLE
docs: add service documentation

### DIFF
--- a/docs/services/admin.md
+++ b/docs/services/admin.md
@@ -1,0 +1,18 @@
+# Admin Service
+
+Administrative endpoints require an authenticated admin account.
+
+## Endpoints
+- `GET /api/v1/admin/ip-whitelist` – retrieve allowed IP addresses for admin operations.
+- `PUT /api/v1/admin/ip-whitelist` – update the IP whitelist with `{ "ips": ["1.1.1.1"] }`.
+
+## Reconcile Partner Balances
+- Script: `npm run reconcile-balances` recomputes balances from settled orders and withdrawals.
+- Admin panel: open a client dashboard and click **Reconcile Balance**.
+
+## Dependencies
+- Prisma Client for database access.
+- Admin authentication middleware.
+
+## Environment Variables
+- `JWT_SECRET` – used to verify admin tokens.

--- a/docs/services/auth.md
+++ b/docs/services/auth.md
@@ -1,0 +1,24 @@
+# Auth Service
+
+## Endpoints
+- `POST /api/v1/auth/login` – login using email, password, and optional OTP.
+- `GET /api/v1/auth/me` – return current authenticated user.
+
+## Dependencies
+- Prisma Client for database access.
+- `bcrypt` for password hashing.
+- `jsonwebtoken` for issuing access tokens.
+- `otplib` for TOTP-based two-factor authentication.
+
+## Environment Variables
+- `JWT_SECRET` – signing key for issued JWTs.
+- `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET` – Auth0 credentials.
+- `AUTH0_AUDIENCE` – expected audience for Auth0 tokens.
+- `AUTH0_MANAGEMENT_ID`, `AUTH0_MANAGEMENT_SECRET` – Auth0 management API access.
+- `AUTH0_TEST_TOKEN` – optional token for testing.
+
+## Getting a Signed JWT
+1. Request Auth0 `domain`, `audience`, and `clientId` from the Launcx team.
+2. Generate an RSA key pair and share the public key with Launcx.
+3. Sign a JWT payload with the private key using algorithm `RS256`.
+4. Exchange the signed JWT at `https://<domain>/oauth/token` to obtain an access token.

--- a/docs/services/client.md
+++ b/docs/services/client.md
@@ -1,0 +1,28 @@
+# Client Service
+
+Endpoints served under `/api/v1/client`.
+
+## Endpoints
+- `POST /register` – register a partner client account.
+- `POST /login` – login and obtain access token.
+- `POST /2fa/setup` – initiate TOTP 2FA setup.
+- `POST /2fa/enable` – enable TOTP using provided code.
+- `GET /2fa/status` – check 2FA activation state.
+- `GET /callback-url` – retrieve configured callback URL.
+- `POST /callback-url` – update callback URL.
+- `POST /change-password` – change client password.
+- `GET /dashboard` – summary of balance and transactions.
+- `GET /dashboard/export` – export transactions as CSV.
+- `POST /callbacks/:id/retry` – retry sending a transaction callback.
+- `POST /withdrawals/validate-account` – validate bank account before withdrawal.
+- `POST /withdrawals` – request a withdrawal.
+- `GET /withdrawals` – list past withdrawals.
+- `POST /withdrawals/:id/retry` – retry a failed withdrawal.
+
+## Dependencies
+- Express and custom `requireClientAuth` middleware for authentication.
+- Prisma Client for persistence.
+
+## Environment Variables
+- `JWT_SECRET` – key used to verify client tokens.
+- `CALLBACK_WORKER_INTERVAL_MS`, `CALLBACK_WORKER_MAX_ATTEMPTS`, `CALLBACK_WORKER_BATCH_SIZE` – control callback retry worker.

--- a/docs/services/merchant.md
+++ b/docs/services/merchant.md
@@ -1,0 +1,16 @@
+# Merchant Service
+
+Endpoints served under `/api/v1/merchant`.
+
+## Endpoints
+- `GET /stats` – summary statistics for orders.
+- `GET /transactions` – list transactions for the merchant.
+- `GET /transactions/export` – export transactions to Excel.
+
+## Dependencies
+- Prisma Client for querying orders.
+- `ExcelJS` for generating spreadsheets.
+- `authMiddleware` to enforce authentication.
+
+## Environment Variables
+This module does not use service‑specific environment variables.

--- a/docs/services/payment.md
+++ b/docs/services/payment.md
@@ -1,0 +1,27 @@
+# Payment Service
+
+Endpoints served under `/api/v1/payment`.
+
+## Endpoints
+- `POST /create-order` – create an aggregated order for multiple providers.
+- `POST /` – create a direct transaction, returning QR payload or redirect URL.
+- `POST /transaction/callback` – receive payment gateway callbacks.
+- `POST /transaction/callback/gidi` – GIDI QRIS callback endpoint.
+- `POST /transaction/callback/oy/retry/:referenceId` – retry OY callback delivery.
+- `GET /order/:id` – retrieve order details.
+- `GET /order/:id/status` – check payment status.
+
+## Dependencies
+- Prisma Client for persistence.
+- Provider SDKs and HTTP requests via `axios`.
+- Custom provider services (Hilogate, OY, GIDI, etc.).
+
+## Environment Variables
+- General: `BASE_URL`, `CALLBACK_URL`, `CALLBACK_URL_FINISH`, `FORCE_PROVIDER`.
+- Callback worker: `CALLBACK_WORKER_INTERVAL_MS`, `CALLBACK_WORKER_MAX_ATTEMPTS`, `CALLBACK_WORKER_BATCH_SIZE`.
+- Netz configuration: `NETZ_URL`, `NETZ_PARTNER_ID`, `NETZ_PRIVATE_KEY`, `NETZ_CLIENT_SECRET`.
+- Brevo email: `BREVO_URL`, `BREVO_API_KEY`.
+- GudangVoucher: `GV_QRIS_URL`, `GV_STORE_URL`, `GV_MERCHANT_ID`, `GV_MERCHANT_KEY`.
+- OY: `OY_API_KEY`, `OY_USERNAME`, `OY_BASE_URL`.
+- Hilogate: `HILOGATE_MERCHANT_ID`, `HILOGATE_SECRET_KEY`, `HILOGATE_ENV`, `HILOGATE_BASE_URL`.
+- 2C2P redirection: `TCPP_MERCHANT_ID`, `TCPP_SECRET_KEY`, `TCPP_POST_URL`, `TCPP_CURRENCY`.

--- a/readme.md
+++ b/readme.md
@@ -1,73 +1,9 @@
-## Get Signed JWT for Your Credential
-
-1. Ask our team to create your client application for your organization. Our team will provide auth0's `domain` and `audience`, and a specified `clientId`
-2. Launcx use Private JWT Token to authenticate, so you'll need to generate a PEM-formatted private and public key (we provide sample script to generate the keys), which you need to share with Launcx as verification method (only share the public key, keep the private key at a safe place)
-3. Implement a service get your signed jwt (we provide an example for typescript, you can always implement it in your chosen language)
-4. Call Launcx's API to generate token, which will be used to call Launcx's protected endpoints
-
-### Sample Script in Typescript
-
-```
-const clientId = <auth-client-id>;
-const domain = <auth-domain>;
-const audience = <auth-audience>;
-
-const TOKEN_URL = `https://${domain}/oauth/token`;
-
-const payload = {
-  iss: domain,
-  sub: clientId,
-  aud: TOKEN_URL,
-  iat: Math.floor(Date.now() / 1000), // current time
-  exp: Math.floor(Date.now() / 1000) + 60 * 5, // expiration time (5 minutes)
-};
-
-const signedJwt = jwt.sign(payload, privateKey, { algorithm: 'RS256' });
-```
-
-### Generate PEM-formatted Public and Private Keys
-
-```
-# generate private.pem
-openssl genpkey -algorithm RSA -out private.pem -aes256
-
-# generate public.pem
-openssl rsa -pubout -in private.pem -out public.pem
-
-# verify your public key
-openssl pkey -pubin -in public.pem -text
-```
 # laucxserver
 
-## Admin IP Whitelist
+Backend for the Launcx payment aggregator.
 
-Super Admins can restrict certain administrative actions to specific IP addresses.
-
-### API
-
-- `GET /api/v1/admin/ip-whitelist` – returns the list of allowed IPs.
-- `PUT /api/v1/admin/ip-whitelist` – update the allowed IPs with `{ "ips": ["1.1.1.1", "2.2.2.2"] }`.
-
-The whitelist is stored in the `Setting` table under the key `admin_ip_whitelist`.
-If the setting is missing or empty, no IP restriction is applied.
+See [docs/services](docs/services) for service-specific endpoints, dependencies, and environment variables.
 
 ## Reconcile Partner Balances
 
-This script recalculates `PartnerClient` balances based on settled orders and
-pending/completed withdrawals.
-
-```
-npm run reconcile-balances
-```
-
-Make sure database environment variables are set before running the script. The
-script prints a summary of balance adjustments to the console.
-
-### Admin Panel Reconciliation
-
-Admins can also trigger a balance recomputation from the web panel:
-
-1. Log in to the admin panel and open a client's dashboard.
-2. Click **Reconcile Balance** inside the *Active Balance* card.
-3. The server recalculates the balance from settled orders minus withdrawals and the card refreshes with the new value.
-
+Run `npm run reconcile-balances` after setting database environment variables to recompute client balances.


### PR DESCRIPTION
## Summary
- add docs for Auth, Client, Merchant, Payment, and Admin services
- streamline README with link to service docs

## Testing
- `npm test` *(fails: test/settings.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cf7fde04c8328a3d28618c3257820