### PR TITLE
docs: add swagger docs for payment and withdrawal

### DIFF
--- a/docs/api/payment.yaml
+++ b/docs/api/payment.yaml
@@ -1,0 +1,169 @@
+openapi: 3.0.0
+info:
+  title: Payment API
+  version: 1.0.0
+paths:
+  /create-order:
+    post:
+      summary: Create an aggregated order
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderRequest"
+      responses:
+        "200":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderResponse"
+  /:
+    post:
+      summary: Create a direct transaction
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Transaction"
+      responses:
+        "200":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderResponse"
+  /transaction/callback:
+    post:
+      summary: Payment gateway callback
+      responses:
+        "200":
+          description: Callback processed
+  /order/{id}:
+    get:
+      summary: Retrieve order details by ID
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Order details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderResponse"
+  /transaction/callback/gidi:
+    post:
+      summary: GIDI payment callback
+      responses:
+        "200":
+          description: Callback processed
+  /order/{id}/status:
+    get:
+      summary: Check payment status by order ID
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Payment status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaymentStatus"
+  /transaction/callback/oy/retry/{referenceId}:
+    post:
+      summary: Retry OY! callback
+      parameters:
+        - in: path
+          name: referenceId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Retry processed
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    Transaction:
+      type: object
+      required:
+        - merchantName
+        - price
+        - buyer
+        - subMerchantId
+        - sourceProvider
+      properties:
+        merchantName:
+          type: string
+          description: gv / hilogate / …
+        price:
+          type: number
+        buyer:
+          type: string
+        flow:
+          type: string
+          enum:
+            - embed
+            - redirect
+        playerId:
+          type: string
+        subMerchantId:
+          type: string
+        sourceProvider:
+          type: string
+    OrderRequest:
+      type: object
+      required:
+        - amount
+        - userId
+      properties:
+        amount:
+          type: number
+          minimum: 1
+        userId:
+          type: string
+        playerId:
+          type: string
+    OrderResponse:
+      type: object
+      properties:
+        orderId:
+          type: string
+        checkoutUrl:
+          type: string
+        qrPayload:
+          type: string
+        playerId:
+          type: string
+        totalAmount:
+          type: number
+        expiredTs:
+          type: string
+    PaymentStatus:
+      type: object
+      properties:
+        status:
+          type: string
+tags: []

--- a/docs/api/withdrawal.yaml
+++ b/docs/api/withdrawal.yaml
@@ -1,0 +1,117 @@
+openapi: 3.0.0
+info:
+  title: Withdrawal API
+  version: 1.0.0
+paths:
+  /validate-account:
+    post:
+      summary: Validate destination account
+      security:
+        - clientAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidateAccountRequest"
+      responses:
+        "200":
+          description: Account validated
+  /:
+    post:
+      summary: Create a new withdrawal
+      security:
+        - clientAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WithdrawalRequest"
+      responses:
+        "200":
+          description: Withdrawal created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WithdrawalResponse"
+    get:
+      summary: List all withdrawals for this client
+      security:
+        - clientAuth: []
+      responses:
+        "200":
+          description: List of withdrawals
+  /submerchants:
+    get:
+      summary: List sub merchants
+      security:
+        - clientAuth: []
+      responses:
+        "200":
+          description: List of sub merchants
+  /{id}/retry:
+    post:
+      summary: Retry a failed withdrawal
+      security:
+        - clientAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Retry initiated
+components:
+  securitySchemes:
+    clientAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    ValidateAccountRequest:
+      type: object
+      required:
+        - bank_code
+        - account_number
+      properties:
+        bank_code:
+          type: string
+          pattern: ^[0-9]{3}$
+        account_number:
+          type: string
+    WithdrawalRequest:
+      type: object
+      required:
+        - amount
+        - account_no
+        - bank_code
+        - currency
+        - request_id
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+        account_no:
+          type: string
+        bank_code:
+          type: string
+          pattern: ^[0-9]{3}$
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+        description:
+          type: string
+        request_id:
+          type: string
+          format: uuid
+    WithdrawalResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+tags: []

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "callback-worker": "ts-node src/worker/callbackQueue.ts",
     "reconcile-balances": "ts-node --transpile-only scripts/reconcileBalances.ts",
     "test": "node --test -r ts-node/register test/**/*.test.ts",
-    "sync-from-hilogate": "ts-node scripts/sync-from-hilogate.ts"
+    "sync-from-hilogate": "ts-node scripts/sync-from-hilogate.ts",
+    "docs": "ts-node scripts/docs.ts"
 
   },
   "author": "",
@@ -45,6 +46,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "typescript": "^5.6.3",
+    "yaml": "^2.4.2",
     "uuid": "^10.0.0",
     "winston": "^3.14.2"
   },

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,13 @@ See [docs/services](docs/services) for service-specific endpoints, dependencies,
 ## Reconcile Partner Balances
 
 Run `npm run reconcile-balances` after setting database environment variables to recompute client balances.
+
+## API Documentation
+
+Generate and serve Swagger docs for payment and withdrawal routes:
+
+```bash
+npm run docs
+```
+
+This command writes `docs/api/payment.yaml` and `docs/api/withdrawal.yaml` and hosts them at `http://localhost:3001/docs/payment` and `/docs/withdrawal`.

--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -1,0 +1,31 @@
+import express from 'express'
+import fs from 'fs'
+import swaggerJsdoc from 'swagger-jsdoc'
+import swaggerUi from 'swagger-ui-express'
+import YAML from 'yaml'
+
+const app = express()
+
+const genSpec = (title: string, apis: string[], out: string) => {
+  const spec = swaggerJsdoc({
+    definition: {
+      openapi: '3.0.0',
+      info: { title, version: '1.0.0' },
+    },
+    apis,
+  })
+  fs.mkdirSync('docs/api', { recursive: true })
+  fs.writeFileSync(`docs/api/${out}`, YAML.stringify(spec))
+  return spec
+}
+
+const paymentSpec = genSpec('Payment API', ['src/route/payment.routes.ts'], 'payment.yaml')
+const withdrawalSpec = genSpec('Withdrawal API', ['src/route/withdrawals.routes.ts'], 'withdrawal.yaml')
+
+app.use('/docs/payment', swaggerUi.serve, swaggerUi.setup(paymentSpec))
+app.use('/docs/withdrawal', swaggerUi.serve, swaggerUi.setup(withdrawalSpec))
+
+const port = Number(process.env.DOCS_PORT) || 3001
+app.listen(port, () => {
+  console.log(`Docs at http://localhost:${port}/docs/payment and /docs/withdrawal`)
+})

--- a/src/route/payment.routes.ts
+++ b/src/route/payment.routes.ts
@@ -3,6 +3,75 @@ import { Router } from 'express'
 import paymentController from '../controller/payment'
 import apiKeyAuth from '../middleware/apiKeyAuth'
 
+/**
+ * @openapi
+ * components:
+ *   securitySchemes:
+ *     apiKeyAuth:
+ *       type: apiKey
+ *       in: header
+ *       name: x-api-key
+ *   schemas:
+ *     Transaction:
+ *       type: object
+ *       required:
+ *         - merchantName
+ *         - price
+ *         - buyer
+ *         - subMerchantId
+ *         - sourceProvider
+ *       properties:
+ *         merchantName:
+ *           type: string
+ *           description: gv / hilogate / …
+ *         price:
+ *           type: number
+ *         buyer:
+ *           type: string
+ *         flow:
+ *           type: string
+ *           enum: [embed, redirect]
+ *         playerId:
+ *           type: string
+ *         subMerchantId:
+ *           type: string
+ *         sourceProvider:
+ *           type: string
+ *     OrderRequest:
+ *       type: object
+ *       required:
+ *         - amount
+ *         - userId
+ *       properties:
+ *         amount:
+ *           type: number
+ *           minimum: 1
+ *         userId:
+ *           type: string
+ *         playerId:
+ *           type: string
+ *     OrderResponse:
+ *       type: object
+ *       properties:
+ *         orderId:
+ *           type: string
+ *         checkoutUrl:
+ *           type: string
+ *         qrPayload:
+ *           type: string
+ *         playerId:
+ *           type: string
+ *         totalAmount:
+ *           type: number
+ *         expiredTs:
+ *           type: string
+ *     PaymentStatus:
+ *       type: object
+ *       properties:
+ *         status:
+ *           type: string
+ */
+
 const paymentRouter = Router()
 
 // Aggregator flow: create an aggregated order
@@ -11,6 +80,27 @@ paymentRouter.post(
   apiKeyAuth,
   paymentController.createOrder
 )
+/**
+ * @openapi
+ * /create-order:
+ *   post:
+ *     summary: Create an aggregated order
+ *     security:
+ *       - apiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/OrderRequest'
+ *     responses:
+ *       200:
+ *         description: Order created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/OrderResponse'
+ */
 
 // Direct transaction: QR payload or redirect URL
 paymentRouter.post(
@@ -18,12 +108,42 @@ paymentRouter.post(
   apiKeyAuth,
   paymentController.createTransaction
 )
+/**
+ * @openapi
+ * /:
+ *   post:
+ *     summary: Create a direct transaction
+ *     security:
+ *       - apiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Transaction'
+ *     responses:
+ *       200:
+ *         description: Order created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/OrderResponse'
+ */
 
 // Payment gateway callback for transactions
 paymentRouter.post(
   '/transaction/callback',
   paymentController.transactionCallback
 )
+/**
+ * @openapi
+ * /transaction/callback:
+ *   post:
+ *     summary: Payment gateway callback
+ *     responses:
+ *       200:
+ *         description: Callback processed
+ */
 
 // Retrieve order details by ID
 paymentRouter.get(
@@ -31,10 +151,40 @@ paymentRouter.get(
   apiKeyAuth,
   paymentController.getOrder
 )
+/**
+ * @openapi
+ * /order/{id}:
+ *   get:
+ *     summary: Retrieve order details by ID
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Order details
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/OrderResponse'
+ */
 paymentRouter.post(
   '/transaction/callback/gidi',
   paymentController.gidiTransactionCallback,
 )
+/**
+ * @openapi
+ * /transaction/callback/gidi:
+ *   post:
+ *     summary: GIDI payment callback
+ *     responses:
+ *       200:
+ *         description: Callback processed
+ */
 
 // Check payment status by order ID
 paymentRouter.get(
@@ -42,9 +192,45 @@ paymentRouter.get(
   apiKeyAuth,
   paymentController.checkPaymentStatus
 )
+/**
+ * @openapi
+ * /order/{id}/status:
+ *   get:
+ *     summary: Check payment status by order ID
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Payment status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PaymentStatus'
+ */
 paymentRouter.post(
   '/transaction/callback/oy/retry/:referenceId',
   paymentController.retryOyCallback
 );
+/**
+ * @openapi
+ * /transaction/callback/oy/retry/{referenceId}:
+ *   post:
+ *     summary: Retry OY! callback
+ *     parameters:
+ *       - in: path
+ *         name: referenceId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Retry processed
+ */
 
 export default paymentRouter

--- a/src/route/withdrawals.routes.ts
+++ b/src/route/withdrawals.routes.ts
@@ -10,6 +10,60 @@ import {
   listSubMerchants,
 } from '../controller/withdrawals.controller'
 
+/**
+ * @openapi
+ * components:
+ *   securitySchemes:
+ *     clientAuth:
+ *       type: http
+ *       scheme: bearer
+ *   schemas:
+ *     ValidateAccountRequest:
+ *       type: object
+ *       required:
+ *         - bank_code
+ *         - account_number
+ *       properties:
+ *         bank_code:
+ *           type: string
+ *           pattern: '^[0-9]{3}$'
+ *         account_number:
+ *           type: string
+ *     WithdrawalRequest:
+ *       type: object
+ *       required:
+ *         - amount
+ *         - account_no
+ *         - bank_code
+ *         - currency
+ *         - request_id
+ *       properties:
+ *         amount:
+ *           type: integer
+ *           minimum: 1
+ *         account_no:
+ *           type: string
+ *         bank_code:
+ *           type: string
+ *           pattern: '^[0-9]{3}$'
+ *         currency:
+ *           type: string
+ *           minLength: 3
+ *           maxLength: 3
+ *         description:
+ *           type: string
+ *         request_id:
+ *           type: string
+ *           format: uuid
+ *     WithdrawalResponse:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         status:
+ *           type: string
+ */
+
 const router = Router()
 
 // All these need the client to be authenticated
@@ -21,6 +75,23 @@ router.post(
   express.json(),
   validateAccount
 )
+/**
+ * @openapi
+ * /validate-account:
+ *   post:
+ *     summary: Validate destination account
+ *     security:
+ *       - clientAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ValidateAccountRequest'
+ *     responses:
+ *       200:
+ *         description: Account validated
+ */
 
 // 2) Create a new withdrawal
 router.post(
@@ -28,13 +99,56 @@ router.post(
   express.json(),
   requestWithdraw
 )
+/**
+ * @openapi
+ * /:
+ *   post:
+ *     summary: Create a new withdrawal
+ *     security:
+ *       - clientAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WithdrawalRequest'
+ *     responses:
+ *       200:
+ *         description: Withdrawal created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WithdrawalResponse'
+ */
 
 // 3) List all withdrawals for this client
 router.get(
   '/',
   listWithdrawals
 )
+/**
+ * @openapi
+ * /:
+ *   get:
+ *     summary: List all withdrawals for this client
+ *     security:
+ *       - clientAuth: []
+ *     responses:
+ *       200:
+ *         description: List of withdrawals
+ */
 router.get('/submerchants', listSubMerchants)
+/**
+ * @openapi
+ * /submerchants:
+ *   get:
+ *     summary: List sub merchants
+ *     security:
+ *       - clientAuth: []
+ *     responses:
+ *       200:
+ *         description: List of sub merchants
+ */
 
 
 // 4) Retry a failed withdrawal
@@ -43,5 +157,22 @@ router.post(
   express.json(),
   retryWithdrawal
 )
+/**
+ * @openapi
+ * /{id}/retry:
+ *   post:
+ *     summary: Retry a failed withdrawal
+ *     security:
+ *       - clientAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Retry initiated
+ */
 
 export default router


### PR DESCRIPTION
## Summary
- document payment routes with OpenAPI schemas
- document withdrawal routes with OpenAPI schemas
- add script to generate/serve swagger docs

## Testing
- `npm test` *(fails: test/settings.routes.test.ts: test failed)*
- `npm run docs`

------
https://chatgpt.com/codex/tasks/task_e_689cf9e282cc83289c4d66c1ca1cb4da