### PR TITLE
Use serveFiles for swagger specs

### DIFF
--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -22,8 +22,8 @@ const genSpec = (title: string, apis: string[], out: string) => {
 const paymentSpec = genSpec('Payment API', ['src/route/payment.routes.ts'], 'payment.yaml')
 const withdrawalSpec = genSpec('Withdrawal API', ['src/route/withdrawals.routes.ts'], 'withdrawal.yaml')
 
-app.use('/docs/payment', swaggerUi.serve, swaggerUi.setup(paymentSpec))
-app.use('/docs/withdrawal', swaggerUi.serve, swaggerUi.setup(withdrawalSpec))
+app.use('/docs/payment', swaggerUi.serveFiles(paymentSpec), swaggerUi.setup(paymentSpec))
+app.use('/docs/withdrawal', swaggerUi.serveFiles(withdrawalSpec), swaggerUi.setup(withdrawalSpec))
 
 const port = Number(process.env.DOCS_PORT) || 3001
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- use `swaggerUi.serveFiles` to serve payment and withdrawal Swagger specs

## Testing
- `npm test` *(fails: test code failure)*
- `npm run docs`
- `curl -s http://localhost:3001/docs/payment/ | head -n 20`
- `curl -s http://localhost:3001/docs/withdrawal/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689d01fe96808328a6f8f860e0b86da9