### PR TITLE
feat(payment-service): add Dockerfile

### DIFF
--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine
+
+WORKDIR /payment-service
+
+COPY payment-service/package*.json ./
+RUN npm install
+
+COPY payment-service/tsconfig.json ./
+COPY payment-service/src ./src
+COPY shared /shared
+COPY src/prisma /prisma
+
+RUN npx prisma generate --schema=/prisma/schema.prisma
+RUN npm run build
+
+ENV PORT=5100
+EXPOSE ${PORT}
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for payment service to install dependencies, generate Prisma client, build, and run service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f37b4b6888328b2e8df62a2e500c6