### PR TITLE
feat: add Dockerfile for backend service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Generate Prisma client and build the project
+RUN npx prisma generate --schema=src/prisma/schema.prisma
+RUN npm run build
+
+# Set and expose application port
+ENV PORT=5000
+EXPOSE ${PORT}
+
+# Start the application
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- create Dockerfile to install dependencies, generate Prisma client, build, and start app
- expose default port from config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f37b6ed64832892441ec3e296b58b