### PR TITLE
feat: add Dockerfile for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Install dependencies based on the lock file
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Build the application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Production image, copy necessary files and run
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Install only production dependencies
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+
+# Copy built assets
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for frontend next.js app

## Testing
- `npm test`
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f37baf47483288c147fd7ac322b6a