### PR TITLE
Add Docker Compose for microservices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,113 @@
+version: '3.8'
+
+services:
+  mongo:
+    image: mongo:7
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    networks:
+      - launcxnet
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - PORT=5000
+      - DATABASE_URL=mongodb://mongo:27017/launcxdb
+      - JWT_SECRET=supersecret
+    ports:
+      - "5000:5000"
+    depends_on:
+      - mongo
+    networks:
+      - launcxnet
+
+  admin-service:
+    build:
+      context: ./admin-service
+      dockerfile: Dockerfile
+    environment:
+      - PORT=5001
+      - DATABASE_URL=mongodb://mongo:27017/launcxdb
+      - JWT_SECRET=supersecret
+    ports:
+      - "5001:5001"
+    depends_on:
+      - mongo
+    networks:
+      - launcxnet
+
+  auth-service:
+    build:
+      context: ./auth-service
+      dockerfile: Dockerfile
+    environment:
+      - PORT=5002
+      - DATABASE_URL=mongodb://mongo:27017/launcxdb
+      - JWT_SECRET=supersecret
+    ports:
+      - "5002:5002"
+    depends_on:
+      - mongo
+    networks:
+      - launcxnet
+
+  payment-service:
+    build:
+      context: ./payment-service
+      dockerfile: Dockerfile
+    environment:
+      - PORT=5100
+      - DATABASE_URL=mongodb://mongo:27017/launcxdb
+      - JWT_SECRET=supersecret
+    ports:
+      - "5100:5100"
+    depends_on:
+      - mongo
+    networks:
+      - launcxnet
+
+  withdrawal-service:
+    build:
+      context: ./withdrawal-service
+      dockerfile: Dockerfile
+    environment:
+      - PORT=5200
+      - DATABASE_URL=mongodb://mongo:27017/launcxdb
+      - JWT_SECRET=supersecret
+      - HILOGATE_MERCHANT_ID=
+      - HILOGATE_SECRET_KEY=
+      - HILOGATE_ENV=sandbox
+      - HILOGATE_BASE_URL=https://app.hilogate.com
+      - OY_API_KEY=
+      - OY_USERNAME=
+      - OY_BASE_URL=https://api-stg.oyindonesia.com
+    ports:
+      - "5200:5200"
+    depends_on:
+      - mongo
+    networks:
+      - launcxnet
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    environment:
+      - NODE_ENV=production
+    ports:
+      - "3000:3000"
+    depends_on:
+      - gateway
+    networks:
+      - launcxnet
+
+networks:
+  launcxnet:
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- add docker-compose setup for gateway, microservices, frontend, and MongoDB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3a468e308328b0c931b17389a0b4