### PR TITLE
Add Kafka broker and switch examples to MongoDB

### DIFF
--- a/admin-service/.env.example
+++ b/admin-service/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL=postgresql://launcx:secret@db:5432/launcx
+DATABASE_URL=mongodb://mongo:27017/launcxdb
 KAFKA_BROKER=kafka:9092
 JWT_SECRET=supersecret

--- a/auth-service/.env.example
+++ b/auth-service/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://launcx:secret@db:5432/launcx
+DATABASE_URL=mongodb://mongo:27017/launcxdb
 KAFKA_BROKER=kafka:9092
 JWT_SECRET=supersecret
 AUTH0_DOMAIN=example.auth0.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,29 @@ services:
     networks:
       - launcxnet
 
+  zookeeper:
+    image: bitnami/zookeeper:3
+    restart: always
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    networks:
+      - launcxnet
+
+  kafka:
+    image: bitnami/kafka:3
+    restart: always
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    networks:
+      - launcxnet
+
   gateway:
     build:
       context: .
@@ -19,10 +42,12 @@ services:
       - PORT=5000
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
+      - KAFKA_BROKER=kafka:9092
     ports:
       - "5000:5000"
     depends_on:
       - mongo
+      - kafka
     networks:
       - launcxnet
 
@@ -34,10 +59,12 @@ services:
       - PORT=5001
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
+      - KAFKA_BROKER=kafka:9092
     ports:
       - "5001:5001"
     depends_on:
       - mongo
+      - kafka
     networks:
       - launcxnet
 
@@ -49,10 +76,12 @@ services:
       - PORT=5002
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
+      - KAFKA_BROKER=kafka:9092
     ports:
       - "5002:5002"
     depends_on:
       - mongo
+      - kafka
     networks:
       - launcxnet
 
@@ -64,10 +93,12 @@ services:
       - PORT=5100
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
+      - KAFKA_BROKER=kafka:9092
     ports:
       - "5100:5100"
     depends_on:
       - mongo
+      - kafka
     networks:
       - launcxnet
 
@@ -79,6 +110,7 @@ services:
       - PORT=5200
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
+      - KAFKA_BROKER=kafka:9092
       - HILOGATE_MERCHANT_ID=
       - HILOGATE_SECRET_KEY=
       - HILOGATE_ENV=sandbox
@@ -90,6 +122,7 @@ services:
       - "5200:5200"
     depends_on:
       - mongo
+      - kafka
     networks:
       - launcxnet
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@
 Dokumen ini menjelaskan contoh struktur Dockerfile serta konfigurasi docker-compose dan Kubernetes untuk setiap service.
 
 ## Dependensi Eksternal
-- **PostgreSQL** sebagai database utama.
+- **MongoDB** sebagai database utama.
 - **Kafka** untuk pub/sub event.
 - Variabel lingkungan umum: `DATABASE_URL` dan `KAFKA_BROKER`.
 
@@ -29,14 +29,10 @@ File berikut menjalankan seluruh service beserta dependensi eksternal.
 ```yaml
 version: "3.8"
 services:
-  db:
-    image: postgres:15
-    environment:
-      POSTGRES_DB: launcx
-      POSTGRES_USER: launcx
-      POSTGRES_PASSWORD: secret
+  mongo:
+    image: mongo:7
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - mongo-data:/data/db
 
   zookeeper:
     image: bitnami/zookeeper:3
@@ -48,6 +44,8 @@ services:
     environment:
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
     depends_on:
       - zookeeper
     ports:
@@ -59,7 +57,7 @@ services:
     ports:
       - "3001:3000"
     depends_on:
-      - db
+      - mongo
       - kafka
 
   admin:
@@ -68,7 +66,7 @@ services:
     ports:
       - "3002:3000"
     depends_on:
-      - db
+      - mongo
       - kafka
 
   client:
@@ -77,7 +75,7 @@ services:
     ports:
       - "3003:3000"
     depends_on:
-      - db
+      - mongo
       - kafka
 
   merchant:
@@ -86,7 +84,7 @@ services:
     ports:
       - "3004:3000"
     depends_on:
-      - db
+      - mongo
       - kafka
 
   payment:
@@ -95,16 +93,16 @@ services:
     ports:
       - "3005:3000"
     depends_on:
-      - db
+      - mongo
       - kafka
 
 volumes:
-  pgdata:
+  mongo-data:
 ```
 
 Setiap berkas `.env` berisi pengaturan berikut:
 
-- `DATABASE_URL=postgresql://launcx:secret@db:5432/launcx`
+- `DATABASE_URL=mongodb://mongo:27017/launcxdb`
 - `KAFKA_BROKER=kafka:9092`
 - Variabel khusus service sesuai dokumen pada `docs/services/*`.
 

--- a/payment-service/.env.example
+++ b/payment-service/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://launcx:secret@db:5432/launcx
+DATABASE_URL=mongodb://mongo:27017/launcxdb
 KAFKA_BROKER=kafka:9092
 
 # General

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ docker-compose up
 Each service reads configuration from a `.env` file in its directory. Copy the corresponding `.env.example` to `.env` and supply the required values. At minimum, set the shared variables:
 
 ```
-DATABASE_URL=postgresql://launcx:secret@db:5432/launcx
+DATABASE_URL=mongodb://mongo:27017/launcxdb
 KAFKA_BROKER=kafka:9092
 ```
 

--- a/withdrawal-service/.env.example
+++ b/withdrawal-service/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://launcx:secret@db:5432/launcx
+DATABASE_URL=mongodb://mongo:27017/launcxdb
 KAFKA_BROKER=kafka:9092
 JWT_SECRET=supersecret
 


### PR DESCRIPTION
## Summary
- add zookeeper and kafka services to docker-compose
- wire services with KAFKA_BROKER
- update env examples, docs, and README to use MongoDB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3e8d6a9c83288f70b1cfbfaa8e91