### PR TITLE
docs: add CS knowledge base

### DIFF
--- a/docs/cs-knowledge/api-faq.md
+++ b/docs/cs-knowledge/api-faq.md
@@ -1,0 +1,24 @@
+---
+title: "FAQ API"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+### Bagaimana cara mendapatkan API key?
+- Merchant masuk ke dashboard.
+- Menu **Pengaturan > API**.
+- API key ditampilkan atau bisa digenerate ulang.
+- **Template balasan:**
+  "Silakan akses dashboard > Pengaturan > API untuk melihat atau membuat API key baru."
+
+### Apakah ada batas rate limit?
+- Ya, default 100 request/menit.
+- Jika perlu lebih, ajukan melalui support.
+
+### Mengapa request saya mendapat `401 Unauthorized`?
+- Periksa header `Authorization` sudah benar.
+- Pastikan API key aktif.
+- Reset API key jika perlu.
+
+### Format waktu apa yang dipakai di API?
+- Semua waktu menggunakan format ISO8601 (UTC).

--- a/docs/cs-knowledge/error-catalog.md
+++ b/docs/cs-knowledge/error-catalog.md
@@ -1,0 +1,12 @@
+---
+title: "Katalog Error"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+| Kode | Arti Singkat | Langkah Cepat |
+|------|--------------|---------------|
+| 500  | Kesalahan server umum | Minta merchant coba ulang, cek status di dashboard. Eskalasi jika berulang. |
+| 1450001 | QRIS: Merchant tidak aktif | Pastikan MID aktif, minta merchant hubungi bank penerbit. |
+| 4001 | Saldo tidak cukup | Informasikan merchant untuk top up saldo. |
+| 9000 | Sistem maintenance | Informasikan estimasi selesai dari notifikasi sistem. |

--- a/docs/cs-knowledge/glossary.md
+++ b/docs/cs-knowledge/glossary.md
@@ -1,0 +1,13 @@
+---
+title: "Glosarium"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+| Istilah | Arti Sederhana |
+|---------|----------------|
+| MID | Merchant ID, identitas toko di sistem pembayaran |
+| QRIS | Standar kode QR nasional untuk pembayaran di Indonesia |
+| Settlement | Proses pemindahan dana ke rekening merchant |
+| Chargeback | Penarikan kembali dana oleh pemegang kartu |
+| Cron | Jadwal tugas otomatis di server |

--- a/docs/cs-knowledge/index.md
+++ b/docs/cs-knowledge/index.md
@@ -1,0 +1,30 @@
+---
+title: "Pusat Pengetahuan CS"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+# Peta Konten
+
+- [Troubleshooting](./troubleshooting/)
+- [Runbooks](./runbooks/)
+- [Katalog Error](./error-catalog.md)
+- [FAQ API](./api-faq.md)
+- [Glosarium](./glossary.md)
+
+## SOP Eskalasi
+
+1. Cek cepat menggunakan panduan pada dokumen terkait.
+2. Bila masalah berulang atau berdampak luas, catat detail kasus.
+3. Hubungi Lead CS melalui chat internal.
+4. Lead CS mengevaluasi dan eskalasi ke Dev bila perlu.
+
+```mermaid
+flowchart TD
+    CS(\"CS Level 1\") -->|kasus kompleks| LeadCS(Lead CS)
+    LeadCS -->|perlu analisa| Dev(Team Dev)
+    Dev -->|solusi| LeadCS
+    LeadCS --> CS
+```
+
+Catatan: gunakan tiket internal untuk setiap eskalasi.

--- a/docs/cs-knowledge/runbooks/cek-provider-downstream.md
+++ b/docs/cs-knowledge/runbooks/cek-provider-downstream.md
@@ -1,0 +1,18 @@
+---
+title: "Cek Provider Downstream"
+updated: "2025-08-17"
+owner: "Tim Ops"
+---
+
+### Tujuan
+Memastikan masalah bukan dari pihak provider eksternal.
+
+### Langkah
+1. Buka portal monitoring provider di `https://<provider-status>`.
+2. Periksa status layanan dan notifikasi.
+3. Jika ada incident, catat nomor tiket provider.
+4. Informasikan ke Lead CS dan merchant mengenai status provider.
+
+### Kapan Hubungi Dev
+- Dashboard provider normal tetapi error tetap terjadi.
+- Ada perubahan konfigurasi yang tidak terdokumentasi.

--- a/docs/cs-knowledge/runbooks/reset-settlement-cursor.md
+++ b/docs/cs-knowledge/runbooks/reset-settlement-cursor.md
@@ -1,0 +1,21 @@
+---
+title: "Reset Settlement Cursor"
+updated: "2025-08-17"
+owner: "Tim Ops"
+---
+
+### Tujuan
+Mengulang proses settlement yang tertahan.
+
+### Langkah
+1. Login ke server settlement: `ssh ops@<settlement-host>`.
+2. Jalankan perintah:
+   ```bash
+   ./reset-cursor.sh --merchant <MID>
+   ```
+3. Pastikan log menunjukkan `cursor reset success`.
+4. Informasikan ke merchant bahwa settlement akan diproses ulang.
+
+### Kapan Hubungi Dev
+- Skrip gagal dijalankan atau tidak ada respon.
+- Cursor tetap tidak bergerak setelah reset.

--- a/docs/cs-knowledge/runbooks/ubah-cron.md
+++ b/docs/cs-knowledge/runbooks/ubah-cron.md
@@ -1,0 +1,22 @@
+---
+title: "Ubah Jadwal Cron"
+updated: "2025-08-17"
+owner: "Tim Ops"
+---
+
+### Tujuan
+Menyesuaikan jadwal tugas otomatis.
+
+### Langkah
+1. Login ke server terkait: `ssh ops@<server>`.
+2. Edit crontab: `crontab -e`.
+3. Ubah jadwal sesuai kebutuhan, contoh:
+   ```
+   0 2 * * * /usr/local/bin/settlement.sh
+   ```
+4. Simpan dan keluar.
+5. Verifikasi dengan `crontab -l`.
+
+### Kapan Hubungi Dev
+- Tidak yakin perintah yang akan dijalankan.
+- Cron tidak berjalan setelah diubah.

--- a/docs/cs-knowledge/troubleshooting/chargeback.md
+++ b/docs/cs-knowledge/troubleshooting/chargeback.md
@@ -1,0 +1,21 @@
+---
+title: "Penanganan Chargeback"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+### Gejala
+Merchant menerima notifikasi penarikan dana (chargeback) dari transaksi kartu.
+
+### Langkah Cek Cepat
+1. Verifikasi detail transaksi: tanggal, nominal, kartu.
+2. Minta merchant kirim bukti transaksi dan bukti pengiriman barang/jasa.
+3. Catat batas waktu respon dari bank.
+
+### Template Balasan
+"Kami telah menerima permintaan chargeback. Mohon kirim bukti transaksi dan pengiriman dalam waktu 2x24 jam agar kami dapat membantu proses disput."
+
+### Kapan Eskalasi ke Dev
+- Sistem tidak menampilkan detail chargeback.
+- Ada perbedaan data antara dashboard dan bank.
+- Sertakan seluruh bukti dari merchant saat eskalasi.

--- a/docs/cs-knowledge/troubleshooting/deposit-http-500.md
+++ b/docs/cs-knowledge/troubleshooting/deposit-http-500.md
@@ -1,0 +1,21 @@
+---
+title: "Deposit Gagal HTTP 500"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+### Gejala
+Merchant tidak bisa melakukan deposit, dashboard menampilkan pesan "HTTP 500".
+
+### Langkah Cek Cepat
+1. Pastikan koneksi internet merchant stabil.
+2. Cek status layanan di [status page](/) internal.
+3. Cari log transaksi di dashboard admin menggunakan ID transaksi.
+
+### Template Balasan
+"Mohon maaf, sedang terjadi gangguan server saat proses deposit. Silakan coba kembali dalam beberapa menit. Kami pantau lebih lanjut."
+
+### Kapan Eskalasi ke Dev
+- Gangguan terjadi lebih dari 3 kali dalam 1 jam.
+- Banyak merchant melaporkan kasus serupa.
+- Sertakan ID transaksi dan waktu kejadian saat eskalasi.

--- a/docs/cs-knowledge/troubleshooting/error-qris-1450001.md
+++ b/docs/cs-knowledge/troubleshooting/error-qris-1450001.md
@@ -1,0 +1,21 @@
+---
+title: "Error QRIS 1450001"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+### Gejala
+Pembayaran QRIS gagal dengan kode error `1450001`.
+
+### Langkah Cek Cepat
+1. Verifikasi MID merchant sudah aktif.
+2. Pastikan merchant terdaftar di penyelenggara QRIS.
+3. Cek log response dari provider QRIS di dashboard admin.
+
+### Template Balasan
+"Transaksi QRIS ditolak karena status merchant tidak aktif. Mohon hubungi bank penerbit untuk mengaktifkan kembali akun QRIS Anda."
+
+### Kapan Eskalasi ke Dev
+- Jika MID sudah aktif tetapi error tetap muncul.
+- Jika terjadi pada banyak merchant secara bersamaan.
+- Sertakan screenshot log response saat eskalasi.

--- a/docs/cs-knowledge/troubleshooting/settlement-terlewat.md
+++ b/docs/cs-knowledge/troubleshooting/settlement-terlewat.md
@@ -1,0 +1,21 @@
+---
+title: "Settlement Terlewat"
+updated: "2025-08-17"
+owner: "Tim CS"
+---
+
+### Gejala
+Dana seharusnya sudah masuk ke rekening merchant namun belum diterima.
+
+### Langkah Cek Cepat
+1. Pastikan jadwal settlement merchant benar.
+2. Cek status settlement terakhir di dashboard admin.
+3. Konfirmasi ke bank penerima apakah ada penundaan.
+
+### Template Balasan
+"Kami sedang memeriksa proses settlement Anda. Mohon menunggu, biasanya dana akan masuk dalam 1 hari kerja."
+
+### Kapan Eskalasi ke Dev
+- Settlement tertunda lebih dari 1 hari kerja.
+- Nominal besar atau banyak merchant terdampak.
+- Lampirkan ID settlement dan tanggal saat eskalasi.


### PR DESCRIPTION
## Summary
- add customer support knowledge base with escalation SOP and runbooks
- include troubleshooting guides, API FAQ, error catalog, and glossary

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a21fa4614c8328b0940927d7b1fef0