### PR TITLE
feat(admin): add TOTP route mounting

### DIFF
--- a/admin-service/src/app.ts
+++ b/admin-service/src/app.ts
@@ -3,6 +3,7 @@ import dashboardRoutes from './route/dashboard.routes';
 import merchantRoutes from './route/merchant.routes';
 import pgProviderRoutes from './route/pgProvider.routes';
 import ipWhitelistRoutes from './route/ipWhitelist.routes';
+import totpRoutes from './route/totp.routes';
 
 const app = express();
 app.use(express.json());
@@ -11,5 +12,6 @@ app.use('/dashboard', dashboardRoutes);
 app.use('/merchants', merchantRoutes);
 app.use('/pg-providers', pgProviderRoutes);
 app.use('/ip-whitelist', ipWhitelistRoutes);
+app.use('/2fa', totpRoutes);
 
 export default app;


### PR DESCRIPTION
## Summary
- mount TOTP routes for 2FA under `/2fa`

## Testing
- `npm test`
- `cd admin-service && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84b2770908328bcc7fbc2cef7c034