### PR TITLE
feat: expose client web routes via gateway

### DIFF
--- a/src/route/routes.ts
+++ b/src/route/routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import axios, { AxiosResponse } from 'axios';
+import clientWebRoutes from './client/web.routes';
 
 const router = Router();
 
@@ -42,6 +43,7 @@ const services = {
 
 // Auth related services
 router.use('/auth', createProxy(services.auth));
+router.use('/client', clientWebRoutes);
 router.use('/client', createProxy(services.auth));
 
 // Payment service


### PR DESCRIPTION
## Summary
- mount client web routes under `/client` so dashboard, 2FA, and callback endpoints are served directly
- keep proxy fallback so other client endpoints still reach auth service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84d1ee9a48328a316c111b2592d1c