### PR TITLE
Configure gateway service URLs and correct route defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,10 @@ services:
       - DATABASE_URL=mongodb://mongo:27017/launcxdb
       - JWT_SECRET=supersecret
       - KAFKA_BROKER=kafka:9092
+      - AUTH_SERVICE_URL=http://auth-service:5002
+      - ADMIN_SERVICE_URL=http://admin-service:5001
+      - PAYMENT_SERVICE_URL=http://payment-service:5100
+      - WITHDRAWAL_SERVICE_URL=http://withdrawal-service:5200
     ports:
       - "5000:5000"
     depends_on:

--- a/src/route/routes.ts
+++ b/src/route/routes.ts
@@ -35,9 +35,9 @@ function createProxy(target: string, options: ProxyOptions = {}) {
 }
 
 const services = {
-  auth: process.env.AUTH_SERVICE_URL || 'http://localhost:5001',
-  admin: process.env.ADMIN_SERVICE_URL || 'http://localhost:5002',
-  payment: process.env.PAYMENT_SERVICE_URL || 'http://localhost:5003',
+  auth: process.env.AUTH_SERVICE_URL || 'http://localhost:5002',
+  admin: process.env.ADMIN_SERVICE_URL || 'http://localhost:5001',
+  payment: process.env.PAYMENT_SERVICE_URL || 'http://localhost:5100',
   withdrawal: process.env.WITHDRAWAL_SERVICE_URL || 'http://localhost:5200',
 };
 


### PR DESCRIPTION
## Summary
- add auth, admin, payment and withdrawal service URLs to gateway environment
- correct fallback ports in gateway route configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a853eabc088328ad05b8107d7581ea