### PR TITLE
chore: standardize API base URL for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       dockerfile: Dockerfile
     environment:
       - NODE_ENV=production
+      - NEXT_PUBLIC_API_URL=http://gateway:5000
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,6 +105,7 @@ Setiap berkas `.env` berisi pengaturan berikut:
 - `DATABASE_URL=mongodb://mongo:27017/launcxdb`
 - `KAFKA_BROKER=kafka:9092`
 - Variabel khusus service sesuai dokumen pada `docs/services/*`.
+- `NEXT_PUBLIC_API_URL=http://localhost:5000` untuk membuat frontend terhubung ke gateway.
 
 ## Manifest Kubernetes
 Gunakan satu `Deployment` dan `Service` per service. Setelan `replicas` menentukan skala, sedangkan strategi `RollingUpdate` memungkinkan rolling update tanpa downtime.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_API_URL=http://localhost:3000/api/v1
+NEXT_PUBLIC_API_URL=http://localhost:5000
 LAUNCX_API_KEY=


### PR DESCRIPTION
## Summary
- point frontend example config to gateway on port 5000
- document gateway base URL and pass it to frontend via docker-compose

## Testing
- `npm test` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68a854aaabcc83289e81664e91a89b27