### PR TITLE
feat(frontend): default axios base URL

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: process.env.NEXT_PUBLIC_API_URL || '', // default to same-origin gateway
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- default axios baseURL to environment variable or same-origin fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint plugin recommendation)*

------
https://chatgpt.com/codex/tasks/task_e_68a85c50ea4483288af0c1c4b5765850